### PR TITLE
The iso should not have /proc, /dev/, nor /sys

### DIFF
--- a/nabla-lib/storage/storage_linux.go
+++ b/nabla-lib/storage/storage_linux.go
@@ -51,7 +51,8 @@ func CreateIso(dir string) (string, error) {
 		return "", err
 	}
 
-	cmd := exec.Command("genisoimage", "-l", "-r", "-o", fname, absDir)
+	cmd := exec.Command("genisoimage", "-m", "dev", "-m", "sys",
+			"-m", "proc", "-l", "-r", "-o", fname, absDir)
 	err = cmd.Run()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Docker creates a /dev with some files in it. Those are showing up in rumprun's /dev: they shouldn't as those do not really mean anything in rumprun. This change invokes genisofs with `-m dev -m proc -m sys` to avoid them in the iso.

Signed-off-by: Ricardo Koller <kollerr@us.ibm.com>