### PR TITLE
Implemented log propagation hack before rewrite of cli

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,3 +40,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/sirupsen/logrus"


### PR DESCRIPTION
Implement log propagation hack without using CLI parsing, since we need to integrate to support the separate OCI commands instead of deferring to runc. This should propagate the errors from runnc:

```
lumjjb@lumjjb-ThinkPad-P50:~/go/src/github.com/nabla-containers/runnc$ sudo docker run --rm --network=host --runtime=runnc nablact/node-express-nabla
docker: Error response from daemon: OCI runtime create failed: Unable to use host network namespace: unknown.
lumjjb@lumjjb-ThinkPad-P50:~/go/src/github.com/nabla-containers/runnc$ sudo docker run --rm --runtime=runnc ubuntu:16.04
docker: Error response from daemon: OCI runtime create failed: Entrypoint is not a .nabla file: unknown.
```

Signed-off-by: Brandon Lum <lumjjb@gmail.com>