### PR TITLE
Runnc cli pass1

### DIFF
--- a/libcontainer/README.md
+++ b/libcontainer/README.md
@@ -1,0 +1,1 @@
+Currently take out `state_*.go` and perform transitions manually.

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -1,5 +1,8 @@
 package configs
 
 type Config struct {
-	Args []string `json:"args"`
+	Args    []string            `json:"args"`
+	Rootfs  string              `json:"rootfs"`
+	HostUID func() (int, error) `json:"hostuid"`
+	HostGID func() (int, error) `json:"hostgid"`
 }

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -3,6 +3,12 @@ package configs
 type Config struct {
 	Args   []string `json:"args"`
 	Rootfs string   `json:"rootfs"`
+
+    // Version is the version of opencontainer specification that is supported.
+    Version string `json:"version"`
+
+    // Labels are user defined metadata that is stored in the config and populated on the state
+    Labels []string `json:"labels"`
 }
 
 // HostUID returns the UID to run the nabla container as. Default is root.

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -1,8 +1,16 @@
 package configs
 
 type Config struct {
-	Args    []string            `json:"args"`
-	Rootfs  string              `json:"rootfs"`
-	HostUID func() (int, error) `json:"hostuid"`
-	HostGID func() (int, error) `json:"hostgid"`
+	Args   []string `json:"args"`
+	Rootfs string   `json:"rootfs"`
+}
+
+// HostUID returns the UID to run the nabla container as. Default is root.
+func (c Config) HostUID() (int, error) {
+	return 0, nil
+}
+
+// HostGID returns the GID to run the nabla container as. Default is root.
+func (c Config) HostGID() (int, error) {
+	return 0, nil
 }

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -1,0 +1,5 @@
+package configs
+
+type Config struct {
+	Args []string `json:"args"`
+}

--- a/libcontainer/configs/spec.go
+++ b/libcontainer/configs/spec.go
@@ -1,0 +1,9 @@
+package configs
+
+import (
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func ParseSpec(s *specs.Spec) (*Config, error) {
+	return nil, nil
+}

--- a/libcontainer/configs/spec.go
+++ b/libcontainer/configs/spec.go
@@ -3,6 +3,7 @@ package configs
 import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+    "fmt"
 )
 
 // TODO(NABLA)
@@ -18,9 +19,16 @@ func ParseSpec(s *specs.Spec) (*Config, error) {
 		return nil, errors.New("Root is nil")
 	}
 
+    labels := []string{}
+    for k, v := range s.Annotations {
+        labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+    }
+
 	cfg := Config{
 		Args:   s.Process.Args,
 		Rootfs: s.Root.Path,
+        Version: s.Version,
+		Labels: labels,
 	}
 
 	return &cfg, nil

--- a/libcontainer/configs/spec.go
+++ b/libcontainer/configs/spec.go
@@ -4,6 +4,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
+// TODO(NABLA)
 func ParseSpec(s *specs.Spec) (*Config, error) {
 	return nil, nil
 }

--- a/libcontainer/configs/spec.go
+++ b/libcontainer/configs/spec.go
@@ -2,9 +2,26 @@ package configs
 
 import (
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 )
 
 // TODO(NABLA)
 func ParseSpec(s *specs.Spec) (*Config, error) {
-	return nil, nil
+	if s == nil {
+		return nil, errors.New("Spec is nil")
+	}
+	if s.Process == nil || s.Process.Args == nil {
+		return nil, errors.New("Process Args is nil")
+	}
+
+	if s.Root == nil {
+		return nil, errors.New("Root is nil")
+	}
+
+	cfg := Config{
+		Args:   s.Process.Args,
+		Rootfs: s.Root.Path,
+	}
+
+	return &cfg, nil
 }

--- a/libcontainer/console.go
+++ b/libcontainer/console.go
@@ -1,0 +1,15 @@
+package libcontainer
+
+import "io"
+
+// Console represents a pseudo TTY.
+type Console interface {
+	io.ReadWriter
+	io.Closer
+
+	// Path returns the filesystem path to the slave side of the pty.
+	Path() string
+
+	// Fd returns the fd for the master of the pty.
+	Fd() uintptr
+}

--- a/libcontainer/console.go
+++ b/libcontainer/console.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package libcontainer
 
 import "io"

--- a/libcontainer/console_nabla.go
+++ b/libcontainer/console_nabla.go
@@ -1,0 +1,145 @@
+package libcontainer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+
+	"github.com/opencontainers/runc/libcontainer/label"
+)
+
+// NewConsole returns an initalized console that can be used within a container by copying bytes
+// from the master side to the slave that is attached as the tty for the container's init process.
+func NewConsole(uid, gid int) (Console, error) {
+	master, err := os.OpenFile("/dev/ptmx", syscall.O_RDWR|syscall.O_NOCTTY|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	console, err := ptsname(master)
+	if err != nil {
+		return nil, err
+	}
+	if err := unlockpt(master); err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(console, 0600); err != nil {
+		return nil, err
+	}
+	if err := os.Chown(console, uid, gid); err != nil {
+		return nil, err
+	}
+	return &linuxConsole{
+		slavePath: console,
+		master:    master,
+	}, nil
+}
+
+// newConsoleFromPath is an internal function returning an initialized console for use inside
+// a container's MNT namespace.
+func newConsoleFromPath(slavePath string) *linuxConsole {
+	return &linuxConsole{
+		slavePath: slavePath,
+	}
+}
+
+// linuxConsole is a linux psuedo TTY for use within a container.
+type linuxConsole struct {
+	master    *os.File
+	slavePath string
+}
+
+func (c *linuxConsole) Fd() uintptr {
+	return c.master.Fd()
+}
+
+func (c *linuxConsole) Path() string {
+	return c.slavePath
+}
+
+func (c *linuxConsole) Read(b []byte) (int, error) {
+	return c.master.Read(b)
+}
+
+func (c *linuxConsole) Write(b []byte) (int, error) {
+	return c.master.Write(b)
+}
+
+func (c *linuxConsole) Close() error {
+	if m := c.master; m != nil {
+		return m.Close()
+	}
+	return nil
+}
+
+// mount initializes the console inside the rootfs mounting with the specified mount label
+// and applying the correct ownership of the console.
+func (c *linuxConsole) mount(rootfs, mountLabel string) error {
+	oldMask := syscall.Umask(0000)
+	defer syscall.Umask(oldMask)
+	if err := label.SetFileLabel(c.slavePath, mountLabel); err != nil {
+		return err
+	}
+	dest := filepath.Join(rootfs, "/dev/console")
+	f, err := os.Create(dest)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+	if f != nil {
+		f.Close()
+	}
+	return syscall.Mount(c.slavePath, dest, "bind", syscall.MS_BIND, "")
+}
+
+// dupStdio opens the slavePath for the console and dups the fds to the current
+// processes stdio, fd 0,1,2.
+func (c *linuxConsole) dupStdio() error {
+	slave, err := c.open(syscall.O_RDWR)
+	if err != nil {
+		return err
+	}
+	fd := int(slave.Fd())
+	for _, i := range []int{0, 1, 2} {
+		if err := syscall.Dup3(fd, i, 0); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// open is a clone of os.OpenFile without the O_CLOEXEC used to open the pty slave.
+func (c *linuxConsole) open(flag int) (*os.File, error) {
+	r, e := syscall.Open(c.slavePath, flag, 0)
+	if e != nil {
+		return nil, &os.PathError{
+			Op:   "open",
+			Path: c.slavePath,
+			Err:  e,
+		}
+	}
+	return os.NewFile(uintptr(r), c.slavePath), nil
+}
+
+func ioctl(fd uintptr, flag, data uintptr) error {
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, flag, data); err != 0 {
+		return err
+	}
+	return nil
+}
+
+// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
+// unlockpt should be called before opening the slave side of a pty.
+func unlockpt(f *os.File) error {
+	var u int32
+	return ioctl(f.Fd(), syscall.TIOCSPTLCK, uintptr(unsafe.Pointer(&u)))
+}
+
+// ptsname retrieves the name of the first available pts for the given master.
+func ptsname(f *os.File) (string, error) {
+	var n int32
+	if err := ioctl(f.Fd(), syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n))); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("/dev/pts/%d", n), nil
+}

--- a/libcontainer/console_nabla.go
+++ b/libcontainer/console_nabla.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package libcontainer
 
 import (

--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package libcontainer
 
 import (

--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -1,0 +1,153 @@
+package libcontainer
+
+import (
+	"os"
+	"time"
+
+	"github.com/nabla-containers/runnc/libcontainer/configs"
+)
+
+// Status is the status of a container.
+type Status int
+
+const (
+	// Created is the status that denotes the container exists but has not been run yet.
+	Created Status = iota
+	// Running is the status that denotes the container exists and is running.
+	Running
+	// Pausing is the status that denotes the container exists, it is in the process of being paused.
+	Pausing
+	// Paused is the status that denotes the container exists, but all its processes are paused.
+	Paused
+	// Stopped is the status that denotes the container does not have a created or running process.
+	Stopped
+)
+
+func (s Status) String() string {
+	switch s {
+	case Created:
+		return "created"
+	case Running:
+		return "running"
+	case Pausing:
+		return "pausing"
+	case Paused:
+		return "paused"
+	case Stopped:
+		return "stopped"
+	default:
+		return "unknown"
+	}
+}
+
+// BaseState represents the platform agnostic pieces relating to a
+// running container's state
+type BaseState struct {
+	// ID is the container ID.
+	ID string `json:"id"`
+
+	// InitProcessPid is the init process id in the parent namespace.
+	InitProcessPid int `json:"init_process_pid"`
+
+	// InitProcessStartTime is the init process start time in clock cycles since boot time.
+	InitProcessStartTime string `json:"init_process_start"`
+
+	// Created is the unix timestamp for the creation time of the container in UTC
+	Created time.Time `json:"created"`
+
+	// Config is the container's configuration.
+	Config configs.Config `json:"config"`
+}
+
+// BaseContainer is a libcontainer container object.
+//
+// Each container is thread-safe within the same process. Since a container can
+// be destroyed by a separate process, any function may return that the container
+// was not found. BaseContainer includes methods that are platform agnostic.
+type BaseContainer interface {
+	// Returns the ID of the container
+	ID() string
+
+	// Returns the current status of the container.
+	//
+	// errors:
+	// ContainerNotExists - Container no longer exists,
+	// Systemerror - System error.
+	Status() (Status, error)
+
+	// State returns the current container's state information.
+	//
+	// errors:
+	// SystemError - System error.
+	State() (*State, error)
+
+	// Returns the current config of the container.
+	Config() configs.Config
+
+	// Returns the PIDs inside this container. The PIDs are in the namespace of the calling process.
+	//
+	// errors:
+	// ContainerNotExists - Container no longer exists,
+	// Systemerror - System error.
+	//
+	// Some of the returned PIDs may no longer refer to processes in the Container, unless
+	// the Container state is PAUSED in which case every PID in the slice is valid.
+	Processes() ([]int, error)
+
+	// Returns statistics for the container.
+	//
+	// errors:
+	// ContainerNotExists - Container no longer exists,
+	// Systemerror - System error.
+	Stats() (*Stats, error)
+
+	// Set resources of container as configured
+	//
+	// We can use this to change resources when containers are running.
+	//
+	// errors:
+	// SystemError - System error.
+	Set(config configs.Config) error
+
+	// Start a process inside the container. Returns error if process fails to
+	// start. You can track process lifecycle with passed Process structure.
+	//
+	// errors:
+	// ContainerNotExists - Container no longer exists,
+	// ConfigInvalid - config is invalid,
+	// ContainerPaused - Container is paused,
+	// SystemError - System error.
+	Start(process *Process) (err error)
+
+	// Run immediatly starts the process inside the conatiner.  Returns error if process
+	// fails to start.  It does not block waiting for the exec fifo  after start returns but
+	// opens the fifo after start returns.
+	//
+	// errors:
+	// ContainerNotExists - Container no longer exists,
+	// ConfigInvalid - config is invalid,
+	// ContainerPaused - Container is paused,
+	// SystemError - System error.
+	Run(process *Process) (err error)
+
+	// Destroys the container after killing all running processes.
+	//
+	// Any event registrations are removed before the container is destroyed.
+	// No error is returned if the container is already destroyed.
+	//
+	// errors:
+	// SystemError - System error.
+	Destroy() error
+
+	// Signal sends the provided signal code to the container's initial process.
+	//
+	// errors:
+	// SystemError - System error.
+	Signal(s os.Signal) error
+
+	// Exec signals the container to exec the users process at the end of the init.
+	//
+	// errors:
+	// SystemError - System error.
+	Exec() error
+}

--- a/libcontainer/container.go
+++ b/libcontainer/container.go
@@ -143,7 +143,7 @@ type BaseContainer interface {
 	//
 	// errors:
 	// SystemError - System error.
-	Signal(s os.Signal) error
+	Signal(s os.Signal, all bool) error
 
 	// Exec signals the container to exec the users process at the end of the init.
 	//

--- a/libcontainer/container_nabla.go
+++ b/libcontainer/container_nabla.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build linux
 
 package libcontainer

--- a/libcontainer/container_nabla.go
+++ b/libcontainer/container_nabla.go
@@ -1,0 +1,23 @@
+// +build linux
+
+package libcontainer
+
+const stdioFdCount = 3
+
+// State represents a running container's state
+type State struct {
+	BaseState
+
+	// Platform specific fields below here
+}
+
+// Container is a libcontainer container object.
+//
+// Each container is thread-safe within the same process. Since a container can
+// be destroyed by a separate process, any function may return that the container
+// was not found.
+type Container interface {
+	BaseContainer
+
+	// Methods below here are platform specific
+}

--- a/libcontainer/container_nabla.go
+++ b/libcontainer/container_nabla.go
@@ -4,6 +4,8 @@ package libcontainer
 
 import (
 	"github.com/nabla-containers/runnc/libcontainer/configs"
+	"github.com/pkg/errors"
+	"os"
 	"sync"
 	"time"
 )
@@ -41,4 +43,77 @@ type nablaContainer struct {
 	//criuVersion          int
 	state   Status
 	created time.Time
+}
+
+func (c *nablaContainer) Config() configs.Config {
+	return *c.config
+}
+
+// TODO(NABLA)
+func (c *nablaContainer) Status() (Status, error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	var sts Status
+	return sts, errors.New("NablaContainer.Status not implemented")
+}
+
+// TODO(NABLA)
+func (c *nablaContainer) State() (*State, error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return nil, errors.New("NablaContainer.State not implemented")
+}
+
+// TODO(NABLA)
+func (c *nablaContainer) Destroy() error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return errors.New("NablaContainer.Destroy not implemented")
+}
+
+func (c *nablaContainer) ID() string {
+	return c.id
+}
+
+// TODO(NABLA)
+func (c *nablaContainer) Processes() ([]int, error) {
+	return nil, errors.New("NablaContainer.Processes not implemented")
+}
+
+// TODO(NABLA)
+func (c *nablaContainer) Stats() (*Stats, error) {
+	return nil, errors.New("NablaContainer.Stats not implemented")
+}
+
+// TODO(NABLA)
+func (c *nablaContainer) Set(config configs.Config) error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return errors.New("NablaContainer.Set not implemented")
+}
+
+// TODO(NABLA)
+func (c *nablaContainer) Start(process *Process) error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return errors.New("NablaContainer.Start not implemented")
+}
+
+// TODO(NABLA)
+func (c *nablaContainer) Run(process *Process) error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return errors.New("NablaContainer.Run not implemented")
+}
+
+// TODO(NABLA)
+func (c *nablaContainer) Exec() error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return errors.New("NablaContainer.Exec not implemented")
+}
+
+// TODO(NABLA)
+func (c *nablaContainer) Signal(s os.Signal) error {
+	return errors.New("NablaContainer.Signal not implemented")
 }

--- a/libcontainer/container_nabla.go
+++ b/libcontainer/container_nabla.go
@@ -2,6 +2,12 @@
 
 package libcontainer
 
+import (
+	"github.com/nabla-containers/runnc/libcontainer/configs"
+	"sync"
+	"time"
+)
+
 const stdioFdCount = 3
 
 // State represents a running container's state
@@ -20,4 +26,19 @@ type Container interface {
 	BaseContainer
 
 	// Methods below here are platform specific
+}
+
+type nablaContainer struct {
+	id     string
+	root   string
+	config *configs.Config
+	//cgroupManager        cgroups.Manager
+	//initArgs             []string
+	//initProcess          parentProcess
+	//initProcessStartTime string
+	//criuPath             string
+	m sync.Mutex
+	//criuVersion          int
+	state   Status
+	created time.Time
 }

--- a/libcontainer/container_nabla.go
+++ b/libcontainer/container_nabla.go
@@ -40,16 +40,10 @@ type Container interface {
 }
 
 type nablaContainer struct {
-	id     string
-	root   string
-	config *configs.Config
-	//cgroupManager        cgroups.Manager
-	//initArgs             []string
-	//initProcess          parentProcess
-	//initProcessStartTime string
-	//criuPath             string
-	m sync.Mutex
-	//criuVersion          int
+	id      string
+	root    string
+	config  *configs.Config
+	m       sync.Mutex
 	state   *State
 	created time.Time
 }

--- a/libcontainer/errors.go
+++ b/libcontainer/errors.go
@@ -1,0 +1,70 @@
+package libcontainer
+
+import "io"
+
+// ErrorCode is the API error code type.
+type ErrorCode int
+
+// API error codes.
+const (
+	// Factory errors
+	IdInUse ErrorCode = iota
+	InvalidIdFormat
+
+	// Container errors
+	ContainerNotExists
+	ContainerPaused
+	ContainerNotStopped
+	ContainerNotRunning
+	ContainerNotPaused
+
+	// Process errors
+	NoProcessOps
+
+	// Common errors
+	ConfigInvalid
+	ConsoleExists
+	SystemError
+)
+
+func (c ErrorCode) String() string {
+	switch c {
+	case IdInUse:
+		return "Id already in use"
+	case InvalidIdFormat:
+		return "Invalid format"
+	case ContainerPaused:
+		return "Container paused"
+	case ConfigInvalid:
+		return "Invalid configuration"
+	case SystemError:
+		return "System error"
+	case ContainerNotExists:
+		return "Container does not exist"
+	case ContainerNotStopped:
+		return "Container is not stopped"
+	case ContainerNotRunning:
+		return "Container is not running"
+	case ConsoleExists:
+		return "Console exists for process"
+	case ContainerNotPaused:
+		return "Container is not paused"
+	case NoProcessOps:
+		return "No process operations"
+	default:
+		return "Unknown error"
+	}
+}
+
+// Error is the API error type.
+type Error interface {
+	error
+
+	// Returns a verbose string including the error message
+	// and a representation of the stack trace suitable for
+	// printing.
+	Detail(w io.Writer) error
+
+	// Returns the error code for this error.
+	Code() ErrorCode
+}

--- a/libcontainer/errors.go
+++ b/libcontainer/errors.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package libcontainer
 
 import "io"

--- a/libcontainer/factory.go
+++ b/libcontainer/factory.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package libcontainer
 
 import (

--- a/libcontainer/factory.go
+++ b/libcontainer/factory.go
@@ -1,0 +1,45 @@
+package libcontainer
+
+import (
+	"github.com/nabla-containers/runnc/libcontainer/configs"
+)
+
+type Factory interface {
+	// Creates a new container with the given id and starts the initial process inside it.
+	// id must be a string containing only letters, digits and underscores and must contain
+	// between 1 and 1024 characters, inclusive.
+	//
+	// The id must not already be in use by an existing container. Containers created using
+	// a factory with the same path (and file system) must have distinct ids.
+	//
+	// Returns the new container with a running process.
+	//
+	// errors:
+	// IdInUse - id is already in use by a container
+	// InvalidIdFormat - id has incorrect format
+	// ConfigInvalid - config is invalid
+	// Systemerror - System error
+	//
+	// On error, any partially created container parts are cleaned up (the operation is atomic).
+	Create(id string, config *configs.Config) (Container, error)
+
+	// Load takes an ID for an existing container and returns the container information
+	// from the state.  This presents a read only view of the container.
+	//
+	// errors:
+	// Path does not exist
+	// Container is stopped
+	// System error
+	Load(id string) (Container, error)
+
+	// StartInitialization is an internal API to libcontainer used during the reexec of the
+	// container.
+	//
+	// Errors:
+	// Pipe connection error
+	// System error
+	StartInitialization() error
+
+	// Type returns info string about factory type (e.g. lxc, libcontainer...)
+	Type() string
+}

--- a/libcontainer/factory_nabla.go
+++ b/libcontainer/factory_nabla.go
@@ -3,9 +3,9 @@
 package libcontainer
 
 import (
+	"github.com/nabla-containers/runnc/libcontainer/configs"
 	"os"
 	"regexp"
-    "github.com/nabla-containers/runnc/libcontainer/configs"
 )
 
 const (
@@ -27,8 +27,8 @@ func New(root string, options ...func(*NablaFactory) error) (Factory, error) {
 		}
 	}
 	l := &NablaFactory{
-		Root:      root,
-		InitArgs:  []string{"/proc/self/exe", "init"},
+		Root:     root,
+		InitArgs: []string{"/proc/self/exe", "init"},
 	}
 
 	for _, opt := range options {
@@ -50,15 +50,15 @@ type NablaFactory struct {
 }
 
 func (l *NablaFactory) Create(id string, config *configs.Config) (Container, error) {
-    return nil, nil
+	return nil, nil
 }
 
 func (l *NablaFactory) Load(id string) (Container, error) {
-    return nil, nil
+	return nil, nil
 }
 
-func (l *NablaFactory) StartInitialization () error {
-    return nil
+func (l *NablaFactory) StartInitialization() error {
+	return nil
 }
 
 func (l *NablaFactory) Type() string {

--- a/libcontainer/factory_nabla.go
+++ b/libcontainer/factory_nabla.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build linux
 
 package libcontainer

--- a/libcontainer/factory_nabla.go
+++ b/libcontainer/factory_nabla.go
@@ -18,6 +18,7 @@ var (
 	maxIdLen = 1024
 )
 
+// TODO(NABLA)
 // New returns a linux based container factory based in the root directory and
 // configures the factory with the provided option funcs.
 func New(root string, options ...func(*NablaFactory) error) (Factory, error) {
@@ -49,14 +50,17 @@ type NablaFactory struct {
 	InitArgs []string
 }
 
+// TODO(NABLA)
 func (l *NablaFactory) Create(id string, config *configs.Config) (Container, error) {
 	return nil, nil
 }
 
+// TODO(NABLA)
 func (l *NablaFactory) Load(id string) (Container, error) {
 	return nil, nil
 }
 
+// TODO(NABLA)
 func (l *NablaFactory) StartInitialization() error {
 	return nil
 }

--- a/libcontainer/factory_nabla.go
+++ b/libcontainer/factory_nabla.go
@@ -4,6 +4,7 @@ package libcontainer
 
 import (
 	"github.com/nabla-containers/runnc/libcontainer/configs"
+	"github.com/pkg/errors"
 	"os"
 	"regexp"
 )
@@ -18,9 +19,9 @@ var (
 	maxIdLen = 1024
 )
 
-// TODO(NABLA)
 // New returns a linux based container factory based in the root directory and
 // configures the factory with the provided option funcs.
+// TODO(NABLA)
 func New(root string, options ...func(*NablaFactory) error) (Factory, error) {
 	if root != "" {
 		if err := os.MkdirAll(root, 0700); err != nil {
@@ -28,8 +29,8 @@ func New(root string, options ...func(*NablaFactory) error) (Factory, error) {
 		}
 	}
 	l := &NablaFactory{
-		Root:     root,
-		InitArgs: []string{"/proc/self/exe", "init"},
+		Root: root,
+		//InitArgs: []string{"/proc/self/exe", "init"},
 	}
 
 	for _, opt := range options {
@@ -47,12 +48,12 @@ type NablaFactory struct {
 
 	// InitArgs are arguments for calling the init responsibilities for spawning
 	// a container.
-	InitArgs []string
+	//InitArgs []string
 }
 
 // TODO(NABLA)
 func (l *NablaFactory) Create(id string, config *configs.Config) (Container, error) {
-	return nil, nil
+	return nil, errors.New("NablaFactory.Create not implemented")
 }
 
 // TODO(NABLA)

--- a/libcontainer/factory_nabla.go
+++ b/libcontainer/factory_nabla.go
@@ -1,0 +1,66 @@
+// +build linux
+
+package libcontainer
+
+import (
+	"os"
+	"regexp"
+    "github.com/nabla-containers/runnc/libcontainer/configs"
+)
+
+const (
+	stateFilename    = "state.json"
+	execFifoFilename = "exec.fifo"
+)
+
+var (
+	idRegex  = regexp.MustCompile(`^[\w+-\.]+$`)
+	maxIdLen = 1024
+)
+
+// New returns a linux based container factory based in the root directory and
+// configures the factory with the provided option funcs.
+func New(root string, options ...func(*NablaFactory) error) (Factory, error) {
+	if root != "" {
+		if err := os.MkdirAll(root, 0700); err != nil {
+			return nil, err
+		}
+	}
+	l := &NablaFactory{
+		Root:      root,
+		InitArgs:  []string{"/proc/self/exe", "init"},
+	}
+
+	for _, opt := range options {
+		if err := opt(l); err != nil {
+			return nil, err
+		}
+	}
+	return l, nil
+}
+
+// LinuxFactory implements the default factory interface for linux based systems.
+type NablaFactory struct {
+	// Root directory for the factory to store state.
+	Root string
+
+	// InitArgs are arguments for calling the init responsibilities for spawning
+	// a container.
+	InitArgs []string
+}
+
+func (l *NablaFactory) Create(id string, config *configs.Config) (Container, error) {
+    return nil, nil
+}
+
+func (l *NablaFactory) Load(id string) (Container, error) {
+    return nil, nil
+}
+
+func (l *NablaFactory) StartInitialization () error {
+    return nil
+}
+
+func (l *NablaFactory) Type() string {
+	return "nabla"
+}

--- a/libcontainer/factory_nabla.go
+++ b/libcontainer/factory_nabla.go
@@ -48,10 +48,6 @@ func New(root string, options ...func(*NablaFactory) error) (Factory, error) {
 type NablaFactory struct {
 	// Root directory for the factory to store state.
 	Root string
-
-	// InitArgs are arguments for calling the init responsibilities for spawning
-	// a container.
-	//InitArgs []string
 }
 
 // TODO(NABLA)

--- a/libcontainer/factory_nabla.go
+++ b/libcontainer/factory_nabla.go
@@ -101,7 +101,13 @@ func (l *NablaFactory) Create(id string, config *configs.Config) (Container, err
 		id:     id,
 		root:   containerRoot,
 		config: config,
-		state:  Stopped,
+		status: Stopped,
+		state: State{
+			BaseState: BaseState{
+				ID:     id,
+				Config: *config,
+			},
+		},
 	}
 	return c, nil
 }

--- a/libcontainer/factory_nabla.go
+++ b/libcontainer/factory_nabla.go
@@ -134,7 +134,6 @@ func (l *NablaFactory) Load(id string) (Container, error) {
 }
 
 // TODO(NABLA)
-// TODO(824): Implement actual process
 func (l *NablaFactory) StartInitialization() error {
 	return initNabla()
 }

--- a/libcontainer/factory_nabla.go
+++ b/libcontainer/factory_nabla.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/nabla-containers/runnc/libcontainer/configs"
-	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -135,8 +134,9 @@ func (l *NablaFactory) Load(id string) (Container, error) {
 }
 
 // TODO(NABLA)
+// TODO(824): Implement actual process
 func (l *NablaFactory) StartInitialization() error {
-	return errors.New("NablaFactory.StartInitialization not implemented")
+	return initNabla()
 }
 
 func (l *NablaFactory) Type() string {

--- a/libcontainer/factory_nabla.go
+++ b/libcontainer/factory_nabla.go
@@ -3,10 +3,13 @@
 package libcontainer
 
 import (
+	"fmt"
 	"github.com/nabla-containers/runnc/libcontainer/configs"
 	"github.com/pkg/errors"
 	"os"
+	"path/filepath"
 	"regexp"
+	"syscall"
 )
 
 const (
@@ -53,19 +56,76 @@ type NablaFactory struct {
 
 // TODO(NABLA)
 func (l *NablaFactory) Create(id string, config *configs.Config) (Container, error) {
-	return nil, errors.New("NablaFactory.Create not implemented")
+	if l.Root == "" {
+		return nil, fmt.Errorf("invalid root")
+	}
+	if err := l.validateID(id); err != nil {
+		return nil, err
+	}
+	//if err := l.Validator.Validate(config); err != nil {
+	//    return nil, err
+	//}
+	uid, err := config.HostUID()
+	if err != nil {
+		return nil, err
+	}
+	gid, err := config.HostGID()
+	if err != nil {
+		return nil, err
+	}
+	containerRoot := filepath.Join(l.Root, id)
+	if _, err := os.Stat(containerRoot); err == nil {
+		return nil, fmt.Errorf("container with id exists: %v", id)
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+	if err := os.MkdirAll(containerRoot, 0711); err != nil {
+		return nil, err
+	}
+
+	if err := os.Chown(containerRoot, uid, gid); err != nil {
+		return nil, err
+	}
+	fifoName := filepath.Join(containerRoot, execFifoFilename)
+	oldMask := syscall.Umask(0000)
+	if err := syscall.Mkfifo(fifoName, 0622); err != nil {
+		syscall.Umask(oldMask)
+		return nil, err
+	}
+	syscall.Umask(oldMask)
+	if err := os.Chown(fifoName, uid, gid); err != nil {
+		return nil, err
+	}
+
+	c := &nablaContainer{
+		id:     id,
+		root:   containerRoot,
+		config: config,
+		state:  Stopped,
+	}
+	return c, nil
 }
 
 // TODO(NABLA)
 func (l *NablaFactory) Load(id string) (Container, error) {
-	return nil, nil
+	return nil, errors.New("NablaFactory.Load not implemented")
 }
 
 // TODO(NABLA)
 func (l *NablaFactory) StartInitialization() error {
-	return nil
+	return errors.New("NablaFactory.StartInitialization not implemented")
 }
 
 func (l *NablaFactory) Type() string {
 	return "nabla"
+}
+
+func (l *NablaFactory) validateID(id string) error {
+	if !idRegex.MatchString(id) {
+		return fmt.Errorf("invalid id format: %v", id)
+	}
+	if len(id) > maxIdLen {
+		return fmt.Errorf("invalid id format: %v", id)
+	}
+	return nil
 }

--- a/libcontainer/generic_error.go
+++ b/libcontainer/generic_error.go
@@ -1,0 +1,106 @@
+package libcontainer
+
+import (
+	"fmt"
+	"io"
+	"text/template"
+	"time"
+
+	"github.com/opencontainers/runc/libcontainer/stacktrace"
+)
+
+type syncType uint8
+
+const (
+	procReady syncType = iota
+	procError
+	procRun
+	procHooks
+	procResume
+)
+
+type syncT struct {
+	Type syncType `json:"type"`
+}
+
+var errorTemplate = template.Must(template.New("error").Parse(`Timestamp: {{.Timestamp}}
+Code: {{.ECode}}
+{{if .Message }}
+Message: {{.Message}}
+{{end}}
+Frames:{{range $i, $frame := .Stack.Frames}}
+---
+{{$i}}: {{$frame.Function}}
+Package: {{$frame.Package}}
+File: {{$frame.File}}@{{$frame.Line}}{{end}}
+`))
+
+func newGenericError(err error, c ErrorCode) Error {
+	if le, ok := err.(Error); ok {
+		return le
+	}
+	gerr := &genericError{
+		Timestamp: time.Now(),
+		Err:       err,
+		ECode:     c,
+		Stack:     stacktrace.Capture(1),
+	}
+	if err != nil {
+		gerr.Message = err.Error()
+	}
+	return gerr
+}
+
+func newSystemError(err error) Error {
+	return createSystemError(err, "")
+}
+
+func newSystemErrorWithCausef(err error, cause string, v ...interface{}) Error {
+	return createSystemError(err, fmt.Sprintf(cause, v...))
+}
+
+func newSystemErrorWithCause(err error, cause string) Error {
+	return createSystemError(err, cause)
+}
+
+// createSystemError creates the specified error with the correct number of
+// stack frames skipped. This is only to be called by the other functions for
+// formatting the error.
+func createSystemError(err error, cause string) Error {
+	gerr := &genericError{
+		Timestamp: time.Now(),
+		Err:       err,
+		ECode:     SystemError,
+		Cause:     cause,
+		Stack:     stacktrace.Capture(2),
+	}
+	if err != nil {
+		gerr.Message = err.Error()
+	}
+	return gerr
+}
+
+type genericError struct {
+	Timestamp time.Time
+	ECode     ErrorCode
+	Err       error `json:"-"`
+	Cause     string
+	Message   string
+	Stack     stacktrace.Stacktrace
+}
+
+func (e *genericError) Error() string {
+	if e.Cause == "" {
+		return e.Message
+	}
+	frame := e.Stack.Frames[0]
+	return fmt.Sprintf("%s:%d: %s caused %q", frame.File, frame.Line, e.Cause, e.Message)
+}
+
+func (e *genericError) Code() ErrorCode {
+	return e.ECode
+}
+
+func (e *genericError) Detail(w io.Writer) error {
+	return errorTemplate.Execute(w, e)
+}

--- a/libcontainer/generic_error.go
+++ b/libcontainer/generic_error.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package libcontainer
 
 import (

--- a/libcontainer/init_nabla.go
+++ b/libcontainer/init_nabla.go
@@ -1,0 +1,55 @@
+package libcontainer
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+type initConfig struct {
+	Args []string `json:"args"`
+}
+
+func initNabla() error {
+	// Ricardo special
+	time.Sleep(1 * time.Second)
+	fmt.Println("HELLO CALLING FROM START_INITIALIZATION")
+
+	var (
+		pipefd      int
+		envInitPipe = os.Getenv("_LIBCONTAINER_INITPIPE")
+	)
+
+	// Get the INITPIPE.
+	pipefd, err := strconv.Atoi(envInitPipe)
+	if err != nil {
+		return fmt.Errorf("unable to convert _LIBCONTAINER_INITPIPE=%s to int: %s", envInitPipe, err)
+	}
+
+	fmt.Println("Reading config from parent:")
+	pipe := os.NewFile(uintptr(pipefd), "pipe")
+	defer pipe.Close()
+
+	var config *initConfig
+	if err := json.NewDecoder(pipe).Decode(&config); err != nil {
+		return err
+	}
+
+	fmt.Printf("Got config: %v\n", config)
+
+	// clear the current process's environment to clean any libcontainer
+	// specific env vars.
+	os.Clearenv()
+
+	// TODO: WAIT FOR EXEC.FIFO
+
+	if err := syscall.Exec(config.Args[0], config.Args, os.Environ()); err != nil {
+		return err
+	}
+
+	return nil
+
+}

--- a/libcontainer/init_nabla.go
+++ b/libcontainer/init_nabla.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package libcontainer
 
 import (
@@ -51,7 +65,7 @@ func initNabla() error {
 	if _, err := syscall.Write(fd, []byte("0")); err != nil {
 		return newSystemErrorWithCause(err, "write 0 exec fifo")
 	}
-    syscall.Close(fd)
+	syscall.Close(fd)
 	syscall.Close(rootfd)
 
 	if err := syscall.Exec(config.Args[0], config.Args, os.Environ()); err != nil {

--- a/libcontainer/init_nabla.go
+++ b/libcontainer/init_nabla.go
@@ -25,7 +25,6 @@ func initNabla() error {
 		return fmt.Errorf("unable to convert _LIBCONTAINER_INITPIPE=%s to int: %s", envInitPipe, err)
 	}
 
-	fmt.Println("Reading config from parent:")
 	pipe := os.NewFile(uintptr(pipefd), "pipe")
 	defer pipe.Close()
 

--- a/libcontainer/init_nabla.go
+++ b/libcontainer/init_nabla.go
@@ -51,6 +51,7 @@ func initNabla() error {
 	if _, err := syscall.Write(fd, []byte("0")); err != nil {
 		return newSystemErrorWithCause(err, "write 0 exec fifo")
 	}
+    syscall.Close(fd)
 	syscall.Close(rootfd)
 
 	if err := syscall.Exec(config.Args[0], config.Args, os.Environ()); err != nil {

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package libcontainer
 
 import (

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -95,3 +95,29 @@ func (p Process) Signal(sig os.Signal) error {
 	}
 	return p.ops.signal(sig)
 }
+
+// IO holds the process's STDIO
+type IO struct {
+	Stdin  io.WriteCloser
+	Stdout io.ReadCloser
+	Stderr io.ReadCloser
+}
+
+// NewConsole creates new console for process and returns it
+func (p *Process) NewConsole(rootuid, rootgid int) (Console, error) {
+	console, err := NewConsole(rootuid, rootgid)
+	if err != nil {
+		return nil, err
+	}
+	p.consolePath = console.Path()
+	return console, nil
+}
+
+// ConsoleFromPath sets the process's console with the path provided
+func (p *Process) ConsoleFromPath(path string) error {
+	if p.consolePath != "" {
+		return fmt.Errorf("console path already exists for process")
+	}
+	p.consolePath = path
+	return nil
+}

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -1,0 +1,97 @@
+package libcontainer
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"os"
+)
+
+type processOperations interface {
+	wait() (*os.ProcessState, error)
+	signal(sig os.Signal) error
+	pid() int
+}
+
+// Process specifies the configuration and IO for a process inside
+// a container.
+type Process struct {
+	// The command to be run followed by any arguments.
+	Args []string
+
+	// Env specifies the environment variables for the process.
+	Env []string
+
+	// User will set the uid and gid of the executing process running inside the container
+	// local to the container's user and group configuration.
+	User string
+
+	// AdditionalGroups specifies the gids that should be added to supplementary groups
+	// in addition to those that the user belongs to.
+	AdditionalGroups []string
+
+	// Cwd will change the processes current working directory inside the container's rootfs.
+	Cwd string
+
+	// Stdin is a pointer to a reader which provides the standard input stream.
+	Stdin io.Reader
+
+	// Stdout is a pointer to a writer which receives the standard output stream.
+	Stdout io.Writer
+
+	// Stderr is a pointer to a writer which receives the standard error stream.
+	Stderr io.Writer
+
+	// ExtraFiles specifies additional open files to be inherited by the container
+	ExtraFiles []*os.File
+
+	// consolePath is the path to the console allocated to the container.
+	consolePath string
+
+	// Capabilities specify the capabilities to keep when executing the process inside the container
+	// All capabilities not specified will be dropped from the processes capability mask
+	Capabilities []string
+
+	// AppArmorProfile specifies the profile to apply to the process and is
+	// changed at the time the process is execed
+	AppArmorProfile string
+
+	// Label specifies the label to apply to the process.  It is commonly used by selinux
+	Label string
+
+	// NoNewPrivileges controls whether processes can gain additional privileges.
+	NoNewPrivileges *bool
+
+	// Rlimits specifies the resource limits, such as max open files, to set in the container
+	// If Rlimits are not set, the container will inherit rlimits from the parent process
+	//Rlimits []configs.Rlimit
+
+	ops processOperations
+}
+
+// Wait waits for the process to exit.
+// Wait releases any resources associated with the Process
+func (p Process) Wait() (*os.ProcessState, error) {
+	if p.ops == nil {
+		return nil, fmt.Errorf("invalid process")
+	}
+	return p.ops.wait()
+}
+
+// Pid returns the process ID
+func (p Process) Pid() (int, error) {
+	// math.MinInt32 is returned here, because it's invalid value
+	// for the kill() system call.
+	if p.ops == nil {
+		return math.MinInt32, fmt.Errorf("invalid process")
+	}
+	return p.ops.pid(), nil
+}
+
+// Signal sends a signal to the Process.
+func (p Process) Signal(sig os.Signal) error {
+	if p.ops == nil {
+		return fmt.Errorf("invalid process")
+	}
+	return p.ops.signal(sig)
+}

--- a/libcontainer/process_nabla.go
+++ b/libcontainer/process_nabla.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package libcontainer
 
 import (

--- a/libcontainer/process_nabla.go
+++ b/libcontainer/process_nabla.go
@@ -1,1 +1,47 @@
 package libcontainer
+
+import (
+	"os"
+	"syscall"
+)
+
+// InitializeIO creates pipes for use with the process's STDIO
+// and returns the opposite side for each
+func (p *Process) InitializeIO(rootuid, rootgid int) (i *IO, err error) {
+	var fds []uintptr
+	i = &IO{}
+	// cleanup in case of an error
+	defer func() {
+		if err != nil {
+			for _, fd := range fds {
+				syscall.Close(int(fd))
+			}
+		}
+	}()
+	// STDIN
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	fds = append(fds, r.Fd(), w.Fd())
+	p.Stdin, i.Stdin = r, w
+	// STDOUT
+	if r, w, err = os.Pipe(); err != nil {
+		return nil, err
+	}
+	fds = append(fds, r.Fd(), w.Fd())
+	p.Stdout, i.Stdout = w, r
+	// STDERR
+	if r, w, err = os.Pipe(); err != nil {
+		return nil, err
+	}
+	fds = append(fds, r.Fd(), w.Fd())
+	p.Stderr, i.Stderr = w, r
+	// change ownership of the pipes incase we are in a user namespace
+	for _, fd := range fds {
+		if err := syscall.Fchown(int(fd), rootuid, rootgid); err != nil {
+			return nil, err
+		}
+	}
+	return i, nil
+}

--- a/libcontainer/process_nabla.go
+++ b/libcontainer/process_nabla.go
@@ -1,0 +1,1 @@
+package libcontainer

--- a/libcontainer/stats.go
+++ b/libcontainer/stats.go
@@ -1,0 +1,5 @@
+package libcontainer
+
+// Stats contains statistics about the container
+type Stats struct {
+}

--- a/libcontainer/stats.go
+++ b/libcontainer/stats.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package libcontainer
 
 // Stats contains statistics about the container

--- a/runnc-cli/Makefile
+++ b/runnc-cli/Makefile
@@ -6,5 +6,8 @@ build: runnc
 runnc:
 	GOOS=linux GOARCH=amd64 go build -o $@ .
 
+install: runnc
+	sudo cp runnc /usr/local/bin/runnc2
+
 clean:
 	rm -rf runnc

--- a/runnc-cli/create.go
+++ b/runnc-cli/create.go
@@ -52,8 +52,14 @@ to specify command(s) that get run when the container is started.
 	},
 	Action: func(context *cli.Context) error {
 		// TODO: Implement
-		status := -1
-
+		spec, err := setupSpec(context)
+		if err != nil {
+			return err
+		}
+		status, err := startContainer(context, spec, true)
+		if err != nil {
+			return err
+		}
 		// exit with the container's exit status so any external supervisor is
 		// notified of the exit with the correct exit status.
 		os.Exit(status)

--- a/runnc-cli/create.go
+++ b/runnc-cli/create.go
@@ -55,12 +55,12 @@ to specify command(s) that get run when the container is started.
 		// TODO: Implement
 		spec, err := setupSpec(context)
 		if err != nil {
-			return err
+			fatal(err)
 		}
 
 		status, err := startContainer(context, spec, true)
 		if err != nil {
-			return err
+			fatal(err)
 		}
 
 		// exit with the container's exit status so any external supervisor is

--- a/runnc-cli/create.go
+++ b/runnc-cli/create.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -56,10 +57,12 @@ to specify command(s) that get run when the container is started.
 		if err != nil {
 			return err
 		}
+
 		status, err := startContainer(context, spec, true)
 		if err != nil {
 			return err
 		}
+		return errors.New("In Create")
 		// exit with the container's exit status so any external supervisor is
 		// notified of the exit with the correct exit status.
 		os.Exit(status)

--- a/runnc-cli/create.go
+++ b/runnc-cli/create.go
@@ -1,9 +1,22 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
 	"os"
 
-	//"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 

--- a/runnc-cli/create.go
+++ b/runnc-cli/create.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/pkg/errors"
+	//"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -62,7 +62,7 @@ to specify command(s) that get run when the container is started.
 		if err != nil {
 			return err
 		}
-		return errors.New("In Create")
+
 		// exit with the container's exit status so any external supervisor is
 		// notified of the exit with the correct exit status.
 		os.Exit(status)

--- a/runnc-cli/delete.go
+++ b/runnc-cli/delete.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/runnc-cli/delete.go
+++ b/runnc-cli/delete.go
@@ -27,6 +27,6 @@ status of "ubuntu01" as "stopped" the following will delete resources held for
 	},
 	Action: func(context *cli.Context) error {
 		// TODO: implement
-		return fmt.Errorf("Not Implemented")
+		return fmt.Errorf("OCI Delete Not Implemented")
 	},
 }

--- a/runnc-cli/exec.go
+++ b/runnc-cli/exec.go
@@ -83,7 +83,7 @@ following will output a list of processes running in the container:
 	},
 	Action: func(context *cli.Context) error {
 		// TODO: implement
-		return fmt.Errorf("Not Implemented")
+		return fmt.Errorf("OCI Exec Not Implemented")
 	},
 	SkipArgReorder: true,
 }

--- a/runnc-cli/exec.go
+++ b/runnc-cli/exec.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/runnc-cli/init.go
+++ b/runnc-cli/init.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build linux
 
 package main

--- a/runnc-cli/init.go
+++ b/runnc-cli/init.go
@@ -1,0 +1,34 @@
+// +build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/nabla-containers/runnc/libcontainer"
+	"github.com/urfave/cli"
+)
+
+func init() {
+	if len(os.Args) > 1 && os.Args[1] == "init" {
+		runtime.GOMAXPROCS(1)
+		runtime.LockOSThread()
+	}
+}
+
+var initCommand = cli.Command{
+	Name:  "init",
+	Usage: `initialize the namespaces and launch the process (do not call it outside of runc)`,
+	Action: func(context *cli.Context) error {
+		factory, _ := libcontainer.New("")
+		if err := factory.StartInitialization(); err != nil {
+			// as the error is sent back to the parent there is no need to log
+			// or write it to stderr because the parent process will handle this
+			fmt.Println("ERR: %v", err)
+			os.Exit(1)
+		}
+		panic("libcontainer: container init failed to exec")
+	},
+}

--- a/runnc-cli/kill.go
+++ b/runnc-cli/kill.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build linux
 
 package main

--- a/runnc-cli/kill.go
+++ b/runnc-cli/kill.go
@@ -4,9 +4,49 @@ package main
 
 import (
 	"fmt"
-
 	"github.com/urfave/cli"
+	"strconv"
+	"strings"
+	"syscall"
 )
+
+var signalMap = map[string]syscall.Signal{
+	"ABRT":   syscall.SIGABRT,
+	"ALRM":   syscall.SIGALRM,
+	"BUS":    syscall.SIGBUS,
+	"CHLD":   syscall.SIGCHLD,
+	"CLD":    syscall.SIGCLD,
+	"CONT":   syscall.SIGCONT,
+	"FPE":    syscall.SIGFPE,
+	"HUP":    syscall.SIGHUP,
+	"ILL":    syscall.SIGILL,
+	"INT":    syscall.SIGINT,
+	"IO":     syscall.SIGIO,
+	"IOT":    syscall.SIGIOT,
+	"KILL":   syscall.SIGKILL,
+	"PIPE":   syscall.SIGPIPE,
+	"POLL":   syscall.SIGPOLL,
+	"PROF":   syscall.SIGPROF,
+	"PWR":    syscall.SIGPWR,
+	"QUIT":   syscall.SIGQUIT,
+	"SEGV":   syscall.SIGSEGV,
+	"STKFLT": syscall.SIGSTKFLT,
+	"STOP":   syscall.SIGSTOP,
+	"SYS":    syscall.SIGSYS,
+	"TERM":   syscall.SIGTERM,
+	"TRAP":   syscall.SIGTRAP,
+	"TSTP":   syscall.SIGTSTP,
+	"TTIN":   syscall.SIGTTIN,
+	"TTOU":   syscall.SIGTTOU,
+	"UNUSED": syscall.SIGUNUSED,
+	"URG":    syscall.SIGURG,
+	"USR1":   syscall.SIGUSR1,
+	"USR2":   syscall.SIGUSR2,
+	"VTALRM": syscall.SIGVTALRM,
+	"WINCH":  syscall.SIGWINCH,
+	"XCPU":   syscall.SIGXCPU,
+	"XFSZ":   syscall.SIGXFSZ,
+}
 
 var killCommand = cli.Command{
 	Name:  "kill",
@@ -28,7 +68,45 @@ signal to the init process of the "ubuntu01" container:
 		},
 	},
 	Action: func(context *cli.Context) error {
-		// TODO: implement
-		return fmt.Errorf("OCI Kill Not Implemented")
+
+		container, err := getContainer(context)
+		if err != nil {
+			return err
+		}
+
+		sigstr := context.Args().Get(1)
+		if sigstr == "" {
+			sigstr = "SIGTERM"
+		}
+
+		signal, err := parseSignal(sigstr)
+		if err != nil {
+			return err
+		}
+
+		// We ignore the all flag since we are using an older version of
+		// runc libcontainer libraries and we only have a single process
+		if err := container.Signal(signal, context.Bool("all")); err != nil {
+			return err
+		}
+		return nil
 	},
+}
+
+func parseSignal(rawSignal string) (syscall.Signal, error) {
+	s, err := strconv.Atoi(rawSignal)
+	if err == nil {
+		sig := syscall.Signal(s)
+		for _, msig := range signalMap {
+			if sig == msig {
+				return sig, nil
+			}
+		}
+		return -1, fmt.Errorf("unknown signal %q", rawSignal)
+	}
+	signal, ok := signalMap[strings.TrimPrefix(strings.ToUpper(rawSignal), "SIG")]
+	if !ok {
+		return -1, fmt.Errorf("unknown signal %q", rawSignal)
+	}
+	return signal, nil
 }

--- a/runnc-cli/kill.go
+++ b/runnc-cli/kill.go
@@ -29,6 +29,6 @@ signal to the init process of the "ubuntu01" container:
 	},
 	Action: func(context *cli.Context) error {
 		// TODO: implement
-		return fmt.Errorf("Not implemented")
+		return fmt.Errorf("OCI Kill Not Implemented")
 	},
 }

--- a/runnc-cli/local.log
+++ b/runnc-cli/local.log
@@ -1,0 +1,1 @@
+time="2018-08-20T13:31:30-04:00" level=error msg="JSON specification file config.json not found"

--- a/runnc-cli/runnc.go
+++ b/runnc-cli/runnc.go
@@ -89,7 +89,7 @@ func main() {
 		//		checkpointCommand,
 		//		eventsCommand,
 		//		execCommand,
-		//		initCommand,
+		initCommand,
 		//		listCommand,
 		//		pauseCommand,
 		//		psCommand,

--- a/runnc-cli/runnc.go
+++ b/runnc-cli/runnc.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/runnc-cli/runnc.go
+++ b/runnc-cli/runnc.go
@@ -102,7 +102,7 @@ func main() {
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {
 			logrus.SetLevel(logrus.DebugLevel)
-			fmt.Fprintln(os.Stdout, "Setting debug level")
+			fmt.Fprintln(os.Stderr, "Setting debug level")
 		}
 		if path := context.GlobalString("log"); path != "" {
 			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0666)

--- a/runnc-cli/runnc.go
+++ b/runnc-cli/runnc.go
@@ -125,6 +125,7 @@ func main() {
 	// the error on cli.ErrWriter and exit.
 	// Use our own writer here to ensure the log gets sent to the right location.
 	cli.ErrWriter = &FatalWriter{cli.ErrWriter}
+	logrus.Debugf("runnc called with %v", os.Args)
 	if err := app.Run(os.Args); err != nil {
 		fatal(err)
 	}

--- a/runnc-cli/runnc.go
+++ b/runnc-cli/runnc.go
@@ -102,10 +102,12 @@ func main() {
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {
 			logrus.SetLevel(logrus.DebugLevel)
+			fmt.Fprintln(os.Stdout, "Setting debug level")
 		}
 		if path := context.GlobalString("log"); path != "" {
 			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0666)
 			if err != nil {
+				fmt.Fprintln(os.Stdout, err.Error())
 				return err
 			}
 			logrus.SetOutput(f)
@@ -125,7 +127,6 @@ func main() {
 	// the error on cli.ErrWriter and exit.
 	// Use our own writer here to ensure the log gets sent to the right location.
 	cli.ErrWriter = &FatalWriter{cli.ErrWriter}
-	logrus.Debugf("runnc called with %v", os.Args)
 	if err := app.Run(os.Args); err != nil {
 		fatal(err)
 	}

--- a/runnc-cli/start.go
+++ b/runnc-cli/start.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-
 	"github.com/urfave/cli"
 )
 

--- a/runnc-cli/start.go
+++ b/runnc-cli/start.go
@@ -1,7 +1,9 @@
 package main
 
 import (
-	//"fmt"
+	"fmt"
+	"github.com/nabla-containers/runnc/libcontainer"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -15,8 +17,23 @@ are starting. The name you provide for the container instance must be unique on
 your host.`,
 	Description: `The start command executes the user defined process in a created container.`,
 	Action: func(context *cli.Context) error {
-		// TODO: implement
-		return nil
-		//return fmt.Errorf("OCI start Not Implemented")
+		container, err := getContainer(context)
+		if err != nil {
+			return err
+		}
+		status, err := container.Status()
+		if err != nil {
+			return err
+		}
+		switch status {
+		case libcontainer.Created:
+			return container.Exec()
+		case libcontainer.Stopped:
+			return errors.New("cannot start a container that has stopped")
+		case libcontainer.Running:
+			return errors.New("cannot start an already running container")
+		default:
+			return fmt.Errorf("cannot start a container in the %s state\n", status)
+		}
 	},
 }

--- a/runnc-cli/start.go
+++ b/runnc-cli/start.go
@@ -16,6 +16,6 @@ your host.`,
 	Description: `The start command executes the user defined process in a created container.`,
 	Action: func(context *cli.Context) error {
 		// TODO: implement
-		return fmt.Errorf("Not Implemented")
+		return fmt.Errorf("OCI start Not Implemented")
 	},
 }

--- a/runnc-cli/start.go
+++ b/runnc-cli/start.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	//"fmt"
 	"github.com/urfave/cli"
 )
 
@@ -16,6 +16,7 @@ your host.`,
 	Description: `The start command executes the user defined process in a created container.`,
 	Action: func(context *cli.Context) error {
 		// TODO: implement
-		return fmt.Errorf("OCI start Not Implemented")
+		return nil
+		//return fmt.Errorf("OCI start Not Implemented")
 	},
 }

--- a/runnc-cli/start.go
+++ b/runnc-cli/start.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/runnc-cli/state.go
+++ b/runnc-cli/state.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-
 	"github.com/urfave/cli"
 )
 

--- a/runnc-cli/state.go
+++ b/runnc-cli/state.go
@@ -1,8 +1,11 @@
 package main
 
 import (
-	"fmt"
+	"encoding/json"
+	"github.com/opencontainers/runc/libcontainer/utils"
 	"github.com/urfave/cli"
+	"os"
+	"time"
 )
 
 var stateCommand = cli.Command{
@@ -15,6 +18,61 @@ Where "<container-id>" is your name for the instance of the container.`,
 instance of a container.`,
 	Action: func(context *cli.Context) error {
 		// TODO: implement
-		return fmt.Errorf("OCI State Not Implemented")
+		container, err := getContainer(context)
+		if err != nil {
+			fatal(err)
+		}
+
+		state, err := container.State()
+		if err != nil {
+			fatal(err)
+		}
+
+		status, err := container.Status()
+		if err != nil {
+			fatal(err)
+		}
+
+		//bundle, annotations := utils.Annotations(state.Config.Labels)
+		cs := containerState{
+			Version:        state.BaseState.Config.Version,
+			ID:             state.BaseState.ID,
+			InitProcessPid: state.BaseState.InitProcessPid,
+			Status:         status.String(),
+			Bundle:         utils.SearchLabels(state.Config.Labels, "bundle"),
+			Rootfs:         state.BaseState.Config.Rootfs,
+			Created:        state.BaseState.Created,
+		}
+		data, err := json.MarshalIndent(cs, "", "  ")
+		if err != nil {
+			fatal(err)
+		}
+		os.Stdout.Write(data)
+
+		// DEBUG
+		os.Stderr.Write(data)
+
+		return nil
 	},
+}
+
+// containerState represents the platform agnostic pieces relating to a
+// running container's status and state
+type containerState struct {
+	// Version is the OCI version for the container
+	Version string `json:"ociVersion"`
+	// ID is the container ID
+	ID string `json:"id"`
+	// InitProcessPid is the init process id in the parent namespace
+	InitProcessPid int `json:"pid"`
+	// Status is the current status of the container, running, paused, ...
+	Status string `json:"status"`
+	// Bundle is the path on the filesystem to the bundle
+	Bundle string `json:"bundle"`
+	// Rootfs is a path to a directory containing the container's root filesystem.
+	Rootfs string `json:"rootfs"`
+	// Created is the unix timestamp for the creation time of the container in UTC
+	Created time.Time `json:"created"`
+	// Annotations is the user defined annotations added to the config.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/runnc-cli/state.go
+++ b/runnc-cli/state.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/runnc-cli/state.go
+++ b/runnc-cli/state.go
@@ -15,6 +15,6 @@ Where "<container-id>" is your name for the instance of the container.`,
 instance of a container.`,
 	Action: func(context *cli.Context) error {
 		// TODO: implement
-		return fmt.Errorf("Not Implemented")
+		return fmt.Errorf("OCI State Not Implemented")
 	},
 }

--- a/runnc-cli/util.go
+++ b/runnc-cli/util.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/runnc-cli/util.go
+++ b/runnc-cli/util.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
 	"os"
 )
 
@@ -13,4 +16,43 @@ func fatal(err error) {
 	logrus.Error(err)
 	fmt.Fprintln(os.Stderr, err)
 	os.Exit(1)
+}
+
+// setupSpec performs inital setup based on the cli.Context for the container
+func setupSpec(context *cli.Context) (*specs.Spec, error) {
+	bundle := context.String("bundle")
+	if bundle != "" {
+		if err := os.Chdir(bundle); err != nil {
+			return nil, err
+		}
+	}
+	spec, err := loadSpec(specConfig)
+	if err != nil {
+		return nil, err
+	}
+	notifySocket := os.Getenv("NOTIFY_SOCKET")
+	if notifySocket != "" {
+		setupSdNotify(spec, notifySocket)
+	}
+	if os.Geteuid() != 0 {
+		return nil, fmt.Errorf("runc should be run as root")
+	}
+	return spec, nil
+}
+
+// loadSpec loads the specification from the provided path.
+func loadSpec(cPath string) (spec *specs.Spec, err error) {
+	cf, err := os.Open(cPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("JSON specification file %s not found", cPath)
+		}
+		return nil, err
+	}
+	defer cf.Close()
+
+	if err = json.NewDecoder(cf).Decode(&spec); err != nil {
+		return nil, err
+	}
+	return spec, validateProcessSpec(spec.Process)
 }

--- a/runnc-cli/util_nabla.go
+++ b/runnc-cli/util_nabla.go
@@ -18,21 +18,19 @@ var (
 	errEmptyID = errors.New("container id cannot be empty")
 )
 
-/*
 // getContainer returns the specified container instance by loading it from state
 // with the default factory.
 func getContainer(context *cli.Context) (libcontainer.Container, error) {
-    id := context.Args().First()
-    if id == "" {
-        return nil, errEmptyID
-    }
-    factory, err := loadFactory(context)
-    if err != nil {
-        return nil, err
-    }
-    return factory.Load(id)
+	id := context.Args().First()
+	if id == "" {
+		return nil, errEmptyID
+	}
+	factory, err := loadFactory(context)
+	if err != nil {
+		return nil, err
+	}
+	return factory.Load(id)
 }
-*/
 
 // TODO(NABLA)
 func startContainer(context *cli.Context, spec *specs.Spec, create bool) (int, error) {
@@ -72,6 +70,8 @@ func createContainer(context *cli.Context, id string, spec *specs.Spec) (libcont
 	if err != nil {
 		return nil, err
 	}
+
+	config.Labels = append(config.Labels, "bundle="+context.String("bundle"))
 
 	if _, err := os.Stat(config.Rootfs); err != nil {
 		if os.IsNotExist(err) {

--- a/runnc-cli/util_nabla.go
+++ b/runnc-cli/util_nabla.go
@@ -33,6 +33,9 @@ func getContainer(context *cli.Context) (libcontainer.Container, error) {
     return factory.Load(id)
 }
 */
+
+
+// TODO(NABLA)
 func startContainer(context *cli.Context, spec *specs.Spec, create bool) (int, error) {
 	id := context.Args().First()
 	if id == "" {
@@ -59,6 +62,8 @@ func startContainer(context *cli.Context, spec *specs.Spec, create bool) (int, e
 	return r.run(spec.Process)
 }
 
+
+// TODO(NABLA)
 func createContainer(context *cli.Context, id string, spec *specs.Spec) (libcontainer.Container, error) {
 
 	config, err := configs.ParseSpec(spec)
@@ -120,6 +125,7 @@ func setupSdNotify(spec *specs.Spec, notifySocket string) {
 	spec.Process.Env = append(spec.Process.Env, fmt.Sprintf("NOTIFY_SOCKET=%s", notifySocket))
 }
 
+// TODO(NABLA)
 func validateProcessSpec(spec *specs.Process) error {
 	if spec.Cwd == "" {
 		return fmt.Errorf("Cwd property must not be empty")

--- a/runnc-cli/util_nabla.go
+++ b/runnc-cli/util_nabla.go
@@ -34,17 +34,18 @@ func getContainer(context *cli.Context) (libcontainer.Container, error) {
 }
 */
 
-
 // TODO(NABLA)
 func startContainer(context *cli.Context, spec *specs.Spec, create bool) (int, error) {
 	id := context.Args().First()
 	if id == "" {
 		return -1, errEmptyID
 	}
+
 	container, err := createContainer(context, id, spec)
 	if err != nil {
 		return -1, err
 	}
+
 	detach := context.Bool("detach")
 	// Support on-demand socket activation by passing file descriptors into   the container init process.
 	listenFDs := []*os.File{}
@@ -61,7 +62,6 @@ func startContainer(context *cli.Context, spec *specs.Spec, create bool) (int, e
 	}
 	return r.run(spec.Process)
 }
-
 
 // TODO(NABLA)
 func createContainer(context *cli.Context, id string, spec *specs.Spec) (libcontainer.Container, error) {

--- a/runnc-cli/util_nabla.go
+++ b/runnc-cli/util_nabla.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/runnc-cli/util_nabla.go
+++ b/runnc-cli/util_nabla.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/nabla-containers/runnc/libcontainer"
+	"github.com/nabla-containers/runnc/libcontainer/configs"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+var (
+	errEmptyID = errors.New("container id cannot be empty")
+)
+
+/*
+// getContainer returns the specified container instance by loading it from state
+// with the default factory.
+func getContainer(context *cli.Context) (libcontainer.Container, error) {
+    id := context.Args().First()
+    if id == "" {
+        return nil, errEmptyID
+    }
+    factory, err := loadFactory(context)
+    if err != nil {
+        return nil, err
+    }
+    return factory.Load(id)
+}
+*/
+func startContainer(context *cli.Context, spec *specs.Spec, create bool) (int, error) {
+	id := context.Args().First()
+	if id == "" {
+		return -1, errEmptyID
+	}
+	container, err := createContainer(context, id, spec)
+	if err != nil {
+		return -1, err
+	}
+	detach := context.Bool("detach")
+	// Support on-demand socket activation by passing file descriptors into   the container init process.
+	listenFDs := []*os.File{}
+
+	r := &runner{
+		enableSubreaper: !context.Bool("no-subreaper"),
+		shouldDestroy:   true,
+		container:       container,
+		listenFDs:       listenFDs,
+		console:         context.String("console"),
+		detach:          detach,
+		pidFile:         context.String("pid-file"),
+		create:          create,
+	}
+	return r.run(spec.Process)
+}
+
+func createContainer(context *cli.Context, id string, spec *specs.Spec) (libcontainer.Container, error) {
+
+	config, err := configs.ParseSpec(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := os.Stat(config.Rootfs); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("rootfs (%q) does not exist", config.Rootfs)
+		}
+		return nil, err
+	}
+
+	factory, err := loadFactory(context)
+	if err != nil {
+		return nil, err
+	}
+
+	return factory.Create(id, config)
+}
+
+// loadFactory returns the configured factory instance for execing containers.
+func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
+	root := context.GlobalString("root")
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+	return libcontainer.New(abs)
+}
+
+func dupStdio(process *libcontainer.Process, rootuid, rootgid int) error {
+	process.Stdin = os.Stdin
+	process.Stdout = os.Stdout
+	process.Stderr = os.Stderr
+	for _, fd := range []uintptr{
+		os.Stdin.Fd(),
+		os.Stdout.Fd(),
+		os.Stderr.Fd(),
+	} {
+		if err := syscall.Fchown(int(fd), rootuid, rootgid); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func destroy(container libcontainer.Container) {
+	if err := container.Destroy(); err != nil {
+		logrus.Error(err)
+	}
+}
+
+// If systemd is supporting sd_notify protocol, this function will add support
+// for sd_notify protocol from within the container.
+func setupSdNotify(spec *specs.Spec, notifySocket string) {
+	spec.Mounts = append(spec.Mounts, specs.Mount{Destination: notifySocket, Type: "bind", Source: notifySocket, Options: []string{"bind"}})
+	spec.Process.Env = append(spec.Process.Env, fmt.Sprintf("NOTIFY_SOCKET=%s", notifySocket))
+}
+
+func validateProcessSpec(spec *specs.Process) error {
+	if spec.Cwd == "" {
+		return fmt.Errorf("Cwd property must not be empty")
+	}
+	if !filepath.IsAbs(spec.Cwd) {
+		return fmt.Errorf("Cwd must be an absolute path")
+	}
+	if len(spec.Args) == 0 {
+		return fmt.Errorf("args must not be empty")
+	}
+	return nil
+}

--- a/runnc-cli/util_nabla.go
+++ b/runnc-cli/util_nabla.go
@@ -60,6 +60,8 @@ func startContainer(context *cli.Context, spec *specs.Spec, create bool) (int, e
 		pidFile:         context.String("pid-file"),
 		create:          create,
 	}
+	// DEBUG
+	fmt.Printf("Process: %v\n", spec.Process.Args)
 	return r.run(spec.Process)
 }
 

--- a/runnc-cli/util_runner.go
+++ b/runnc-cli/util_runner.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"fmt"
+	"github.com/nabla-containers/runnc/libcontainer"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"os"
+	"strconv"
+	"syscall"
+
+	"path/filepath"
+)
+
+type runner struct {
+	enableSubreaper bool
+	shouldDestroy   bool
+	detach          bool
+	listenFDs       []*os.File
+	pidFile         string
+	console         string
+	container       libcontainer.Container
+	create          bool
+}
+
+func (r *runner) run(config *specs.Process) (int, error) {
+	process, err := newProcess(*config)
+	if err != nil {
+		r.destroy()
+		return -1, err
+	}
+	if len(r.listenFDs) > 0 {
+		process.Env = append(process.Env, fmt.Sprintf("LISTEN_FDS=%d", len(r.listenFDs)), "LISTEN_PID=1")
+		process.ExtraFiles = append(process.ExtraFiles, r.listenFDs...)
+	}
+	rootuid, err := r.container.Config().HostUID()
+	if err != nil {
+		r.destroy()
+		return -1, err
+	}
+	rootgid, err := r.container.Config().HostGID()
+	if err != nil {
+		r.destroy()
+		return -1, err
+	}
+	tty, err := setupIO(process, rootuid, rootgid, r.console, config.Terminal, r.detach || r.create)
+	if err != nil {
+		r.destroy()
+		return -1, err
+	}
+	handler := newSignalHandler(tty, r.enableSubreaper)
+	startFn := r.container.Start
+	if !r.create {
+		startFn = r.container.Run
+	}
+	defer tty.Close()
+	if err := startFn(process); err != nil {
+		r.destroy()
+		return -1, err
+	}
+	if err := tty.ClosePostStart(); err != nil {
+		r.terminate(process)
+		r.destroy()
+		return -1, err
+	}
+	if r.pidFile != "" {
+		if err := createPidFile(r.pidFile, process); err != nil {
+			r.terminate(process)
+			r.destroy()
+			return -1, err
+		}
+	}
+	if r.detach || r.create {
+		return 0, nil
+	}
+	status, err := handler.forward(process)
+	if err != nil {
+		r.terminate(process)
+	}
+	r.destroy()
+	return status, err
+}
+
+func (r *runner) destroy() {
+	if r.shouldDestroy {
+		destroy(r.container)
+	}
+}
+
+func (r *runner) terminate(p *libcontainer.Process) {
+	p.Signal(syscall.SIGKILL)
+	p.Wait()
+}
+
+// newProcess returns a new libcontainer Process with the arguments from the
+// spec and stdio from the current process.
+func newProcess(p specs.Process) (*libcontainer.Process, error) {
+	lp := &libcontainer.Process{
+		Args: p.Args,
+		Env:  p.Env,
+		// TODO: fix libcontainer's API to better support uid/gid in a typesafe way.
+		User:            fmt.Sprintf("%d:%d", p.User.UID, p.User.GID),
+		Cwd:             p.Cwd,
+		Label:           p.SelinuxLabel,
+		NoNewPrivileges: &p.NoNewPrivileges,
+		AppArmorProfile: p.ApparmorProfile,
+	}
+	for _, gid := range p.User.AdditionalGids {
+		lp.AdditionalGroups = append(lp.AdditionalGroups, strconv.FormatUint(uint64(gid), 10))
+	}
+
+	return lp, nil
+}
+
+// setupIO sets the proper IO on the process depending on the configuration
+// If there is a nil error then there must be a non nil tty returned
+func setupIO(process *libcontainer.Process, rootuid, rootgid int, console string, createTTY, detach bool) (*tty, error) {
+	// detach and createTty will not work unless a console path is passed
+	// so error out here before changing any terminal settings
+	if createTTY && detach && console == "" {
+		return nil, fmt.Errorf("cannot allocate tty if runc will detach")
+	}
+	if createTTY {
+		return createTty(process, rootuid, rootgid, console)
+	}
+	if detach {
+		if err := dupStdio(process, rootuid, rootgid); err != nil {
+			return nil, err
+		}
+		return &tty{}, nil
+	}
+	return createStdioPipes(process, rootuid, rootgid)
+}
+
+// createPidFile creates a file with the processes pid inside it atomically
+// it creates a temp file with the paths filename + '.' infront of it
+// then renames the file
+func createPidFile(path string, process *libcontainer.Process) error {
+	pid, err := process.Pid()
+	if err != nil {
+		return err
+	}
+	var (
+		tmpDir  = filepath.Dir(path)
+		tmpName = filepath.Join(tmpDir, fmt.Sprintf(".%s", filepath.Base(path)))
+	)
+	f, err := os.OpenFile(tmpName, os.O_RDWR|os.O_CREATE|os.O_EXCL|os.O_SYNC, 0666)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(f, "%d", pid)
+	f.Close()
+	if err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/runnc-cli/util_runner.go
+++ b/runnc-cli/util_runner.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/runnc-cli/util_signal.go
+++ b/runnc-cli/util_signal.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/nabla-containers/runnc/libcontainer"
+	"github.com/opencontainers/runc/libcontainer/system"
+	"github.com/opencontainers/runc/libcontainer/utils"
+	"github.com/sirupsen/logrus"
+)
+
+const signalBufferSize = 2048
+
+// newSignalHandler returns a signal handler for processing SIGCHLD and SIGWINCH signals
+// while still forwarding all other signals to the process.
+func newSignalHandler(tty *tty, enableSubreaper bool) *signalHandler {
+	if enableSubreaper {
+		// set us as the subreaper before registering the signal handler for the container
+		if err := system.SetSubreaper(1); err != nil {
+			logrus.Warn(err)
+		}
+	}
+	// ensure that we have a large buffer size so that we do not miss any signals
+	// incase we are not processing them fast enough.
+	s := make(chan os.Signal, signalBufferSize)
+	// handle all signals for the process.
+	signal.Notify(s)
+	return &signalHandler{
+		tty:     tty,
+		signals: s,
+	}
+}
+
+// exit models a process exit status with the pid and
+// exit status.
+type exit struct {
+	pid    int
+	status int
+}
+
+type signalHandler struct {
+	signals chan os.Signal
+	tty     *tty
+}
+
+// forward handles the main signal event loop forwarding, resizing, or reaping depending
+// on the signal received.
+func (h *signalHandler) forward(process *libcontainer.Process) (int, error) {
+	// make sure we know the pid of our main process so that we can return
+	// after it dies.
+	pid1, err := process.Pid()
+	if err != nil {
+		return -1, err
+	}
+	// perform the initial tty resize.
+	h.tty.resize()
+	for s := range h.signals {
+		switch s {
+		case syscall.SIGWINCH:
+			h.tty.resize()
+		case syscall.SIGCHLD:
+			exits, err := h.reap()
+			if err != nil {
+				logrus.Error(err)
+			}
+			for _, e := range exits {
+				logrus.WithFields(logrus.Fields{
+					"pid":    e.pid,
+					"status": e.status,
+				}).Debug("process exited")
+				if e.pid == pid1 {
+					// call Wait() on the process even though we already have the exit
+					// status because we must ensure that any of the go specific process
+					// fun such as flushing pipes are complete before we return.
+					process.Wait()
+					return e.status, nil
+				}
+			}
+		default:
+			logrus.Debugf("sending signal to process %s", s)
+			if err := syscall.Kill(pid1, s.(syscall.Signal)); err != nil {
+				logrus.Error(err)
+			}
+		}
+	}
+	return -1, nil
+}
+
+// reap runs wait4 in a loop until we have finished processing any existing exits
+// then returns all exits to the main event loop for further processing.
+func (h *signalHandler) reap() (exits []exit, err error) {
+	var (
+		ws  syscall.WaitStatus
+		rus syscall.Rusage
+	)
+	for {
+		pid, err := syscall.Wait4(-1, &ws, syscall.WNOHANG, &rus)
+		if err != nil {
+			if err == syscall.ECHILD {
+				return exits, nil
+			}
+			return nil, err
+		}
+		if pid <= 0 {
+			return exits, nil
+		}
+		exits = append(exits, exit{
+			pid:    pid,
+			status: utils.ExitStatus(ws),
+		})
+	}
+}

--- a/runnc-cli/util_signal.go
+++ b/runnc-cli/util_signal.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/runnc-cli/util_tty.go
+++ b/runnc-cli/util_tty.go
@@ -1,0 +1,126 @@
+// +build linux
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/docker/docker/pkg/term"
+	"github.com/nabla-containers/runnc/libcontainer"
+)
+
+// setup standard pipes so that the TTY of the calling runc process
+// is not inherited by the container.
+func createStdioPipes(p *libcontainer.Process, rootuid, rootgid int) (*tty, error) {
+	i, err := p.InitializeIO(rootuid, rootgid)
+	if err != nil {
+		return nil, err
+	}
+	t := &tty{
+		closers: []io.Closer{
+			i.Stdin,
+			i.Stdout,
+			i.Stderr,
+		},
+	}
+	// add the process's io to the post start closers if they support close
+	for _, cc := range []interface{}{
+		p.Stdin,
+		p.Stdout,
+		p.Stderr,
+	} {
+		if c, ok := cc.(io.Closer); ok {
+			t.postStart = append(t.postStart, c)
+		}
+	}
+	go func() {
+		io.Copy(i.Stdin, os.Stdin)
+		i.Stdin.Close()
+	}()
+	t.wg.Add(2)
+	go t.copyIO(os.Stdout, i.Stdout)
+	go t.copyIO(os.Stderr, i.Stderr)
+	return t, nil
+}
+
+func (t *tty) copyIO(w io.Writer, r io.ReadCloser) {
+	defer t.wg.Done()
+	io.Copy(w, r)
+	r.Close()
+}
+
+func createTty(p *libcontainer.Process, rootuid, rootgid int, consolePath string) (*tty, error) {
+	if consolePath != "" {
+		if err := p.ConsoleFromPath(consolePath); err != nil {
+			return nil, err
+		}
+		return &tty{}, nil
+	}
+	console, err := p.NewConsole(rootuid, rootgid)
+	if err != nil {
+		return nil, err
+	}
+	go io.Copy(console, os.Stdin)
+	go io.Copy(os.Stdout, console)
+
+	state, err := term.SetRawTerminal(os.Stdin.Fd())
+	if err != nil {
+		return nil, fmt.Errorf("failed to set the terminal from the stdin: %v", err)
+	}
+	return &tty{
+		console: console,
+		state:   state,
+		closers: []io.Closer{
+			console,
+		},
+	}, nil
+}
+
+type tty struct {
+	console   libcontainer.Console
+	state     *term.State
+	closers   []io.Closer
+	postStart []io.Closer
+	wg        sync.WaitGroup
+}
+
+// ClosePostStart closes any fds that are provided to the container and dup2'd
+// so that we no longer have copy in our process.
+func (t *tty) ClosePostStart() error {
+	for _, c := range t.postStart {
+		c.Close()
+	}
+	return nil
+}
+
+// Close closes all open fds for the tty and/or restores the orignal
+// stdin state to what it was prior to the container execution
+func (t *tty) Close() error {
+	// ensure that our side of the fds are always closed
+	for _, c := range t.postStart {
+		c.Close()
+	}
+	// wait for the copy routines to finish before closing the fds
+	t.wg.Wait()
+	for _, c := range t.closers {
+		c.Close()
+	}
+	if t.state != nil {
+		term.RestoreTerminal(os.Stdin.Fd(), t.state)
+	}
+	return nil
+}
+
+func (t *tty) resize() error {
+	if t.console == nil {
+		return nil
+	}
+	ws, err := term.GetWinsize(os.Stdin.Fd())
+	if err != nil {
+		return err
+	}
+	return term.SetWinsize(t.console.Fd(), ws)
+}

--- a/runnc-cli/util_tty.go
+++ b/runnc-cli/util_tty.go
@@ -1,3 +1,17 @@
+// Copyright 2014 Docker, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build linux
 
 package main


### PR DESCRIPTION
Implemented a runtime that runs processes directly on the host, implementing the entire runtime spec container lifecycle.

- Implemented OCI: `create, start, state, kill, delete`
- Non-OCI helpers: `init`
- No network support.

Implementation largely based on similar `runc` taking from versions 0.1 as well as current master.