### PR TITLE
Made changes to handle pause container so that k8s can use runnc (minus network)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - echo "deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get -qq update
   - sudo apt-get install -y libseccomp-dev/trusty-backports genisoimage
-  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
   - go get -u github.com/vbatts/git-validation
   - go get -u github.com/golang/dep/cmd/dep
   - env | grep TRAVIS_

--- a/libcontainer/init_nabla.go
+++ b/libcontainer/init_nabla.go
@@ -53,7 +53,7 @@ func nablaRunArgs(cfg *initConfig) ([]string, error) {
 	args = append(args, "--")
 	args = append(args, cfg.Args[1:]...)
 
-	fmt.Printf("Running with args: %v", args)
+	fmt.Fprintf(os.Stderr, "Running with args: %v", args)
 	return args, nil
 }
 
@@ -107,6 +107,11 @@ func initNabla() error {
 	}
 	syscall.Close(fd)
 	syscall.Close(rootfd)
+
+	// Check if it is a pause container, if it is, just pause
+	if len(config.Args) == 1 && config.Args[0] == pauseNablaName {
+		select {}
+	}
 
 	runArgs, err := nablaRunArgs(config)
 	if err != nil {

--- a/nabla-lib/storage/storage_linux.go
+++ b/nabla-lib/storage/storage_linux.go
@@ -20,6 +20,7 @@
 package storage
 
 import (
+	"github.com/pkg/errors"
 	"io/ioutil"
 	"os/exec"
 	"path/filepath"
@@ -52,20 +53,20 @@ func CreateIso(dir string, target *string) (string, error) {
 		var err error
 		fname, err = filepath.Abs(*target)
 		if err != nil {
-			return "", err
+			return "", errors.Wrap(err, "Unable to resolve abs target path")
 		}
 	}
 
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "Unable to resolve abs dir path")
 	}
 
 	cmd := exec.Command("genisoimage", "-m", "dev", "-m", "sys",
 		"-m", "proc", "-l", "-r", "-o", fname, absDir)
 	err = cmd.Run()
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "Unable to run geniso command")
 	}
 
 	return fname, nil

--- a/runnc-cli/util.go
+++ b/runnc-cli/util.go
@@ -21,6 +21,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 // fatal prints the error's details if it is a libcontainer specific error type
@@ -44,6 +46,11 @@ func setupSpec(context *cli.Context) (*specs.Spec, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if spec.Root != nil && !strings.HasPrefix(spec.Root.Path, "/") {
+		spec.Root.Path = filepath.Join(bundle, spec.Root.Path)
+	}
+
 	notifySocket := os.Getenv("NOTIFY_SOCKET")
 	if notifySocket != "" {
 		setupSdNotify(spec, notifySocket)


### PR DESCRIPTION
k8s uses a pause container as a placeholder to set up networking with CNI. We simulate a pause container when requested by blocking in the init function.

Signed-off-by: Brandon Lum <lumjjb@gmail.com>