### PR TITLE
Added networking hack for CNI namespaced veth pairs

### DIFF
--- a/hack/copy_binaries.sh
+++ b/hack/copy_binaries.sh
@@ -21,6 +21,8 @@ BIN_PATH=/usr/local/bin/
 BIN_PATH2=/opt/runnc/bin/
 COPY_BINS=("build/runnc" "build/runnc-cont" "build/nabla-run")
 
+mkdir -p ${BIN_PATH2}
+
 for i in ${COPY_BINS[@]}; do
     echo $i
     cp $i ${BIN_PATH}/

--- a/hack/copy_binaries.sh
+++ b/hack/copy_binaries.sh
@@ -18,7 +18,11 @@
 # PERFORMANCE OF THIS SOFTWARE.
 
 BIN_PATH=/usr/local/bin/
+
+# We add binaries like runnc-cont and nabla-run to /opt/X since they are not 
+# to be consumed directly by the user.
 BIN_PATH2=/opt/runnc/bin/
+
 COPY_BINS=("build/runnc" "build/runnc-cont" "build/nabla-run")
 
 mkdir -p ${BIN_PATH2}

--- a/hack/copy_binaries.sh
+++ b/hack/copy_binaries.sh
@@ -18,9 +18,11 @@
 # PERFORMANCE OF THIS SOFTWARE.
 
 BIN_PATH=/usr/local/bin/
+BIN_PATH2=/opt/runnc/bin/
 COPY_BINS=("build/runnc" "build/runnc-cont" "build/nabla-run")
 
 for i in ${COPY_BINS[@]}; do
     echo $i
     cp $i ${BIN_PATH}/
+    cp $i ${BIN_PATH2}/
 done

--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -11,6 +11,9 @@ type Config struct {
 
 	// Labels are user defined metadata that is stored in the config and populated on the state
 	Labels []string `json:"labels"`
+
+	// Network namespace
+	NetnsPath string `json:"netnspath"`
 }
 
 // HostUID returns the UID to run the nabla container as. Default is root.

--- a/libcontainer/configs/spec.go
+++ b/libcontainer/configs/spec.go
@@ -23,13 +23,23 @@ func ParseSpec(s *specs.Spec) (*Config, error) {
 		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
 	}
 
+	netnsPath := ""
+	if s.Linux != nil {
+		for _, v := range s.Linux.Namespaces {
+			if v.Type == specs.NetworkNamespace {
+				netnsPath = v.Path
+			}
+		}
+	}
+
 	cfg := Config{
-		Args:    s.Process.Args,
-		Rootfs:  s.Root.Path,
-		Env:     s.Process.Env,
-		Cwd:     s.Process.Cwd,
-		Version: s.Version,
-		Labels:  labels,
+		Args:      s.Process.Args,
+		Rootfs:    s.Root.Path,
+		Env:       s.Process.Env,
+		Cwd:       s.Process.Cwd,
+		Version:   s.Version,
+		NetnsPath: netnsPath,
+		Labels:    labels,
 	}
 
 	return &cfg, nil

--- a/libcontainer/container_nabla.go
+++ b/libcontainer/container_nabla.go
@@ -202,12 +202,13 @@ func (c *nablaContainer) start(p *Process) error {
 
 	defer parentPipe.Close()
 	config := initConfig{
-		Root:    c.config.Rootfs,
-		Args:    c.config.Args,
-		FsPath:  c.fsPath,
-		Cwd:     c.config.Cwd,
-		Env:     c.config.Env,
-		TapName: nablaTapName(c.id),
+		Root:      c.config.Rootfs,
+		Args:      c.config.Args,
+		FsPath:    c.fsPath,
+		Cwd:       c.config.Cwd,
+		Env:       c.config.Env,
+		TapName:   nablaTapName(c.id),
+		NetnsPath: c.config.NetnsPath,
 	}
 
 	enc := json.NewEncoder(parentPipe)

--- a/nabla-lib/network/network_linux.go
+++ b/nabla-lib/network/network_linux.go
@@ -159,12 +159,12 @@ func CreateMacvtapInterfaceDocker(tapName *string, master string) (
 
 	netHandle, err := netlink.NewHandle()
 	if err != nil {
-		return nil, nil, nil, "", err
+		return nil, nil, nil, "", errors.Wrap(err, "Unable to create netlink handler")
 	}
 
 	err = SetupTunDev()
 	if err != nil {
-		return nil, nil, nil, "", err
+		return nil, nil, nil, "", errors.Wrap(err, "Unable to setup tun dev")
 	}
 
 	masterLink, err := netlink.LinkByName(master)
@@ -175,13 +175,13 @@ func CreateMacvtapInterfaceDocker(tapName *string, master string) (
 
 	macvtapLink, name, tapNameTmp, err := createMacvtapInterface(netHandle, masterLink)
 	if err != nil {
-		return nil, nil, nil, "", err
+		return nil, nil, nil, "", errors.Wrap(err, "Unable to create Macvtapint")
 	}
 	*tapName = tapNameTmp
 
 	addrs, err := netlink.AddrList(masterLink, netlink.FAMILY_V4)
 	if err != nil {
-		return nil, nil, nil, "", err
+		return nil, nil, nil, "", errors.Wrap(err, "Unable to get address list")
 	}
 	if len(addrs) == 0 {
 		return nil, nil, nil, "", fmt.Errorf("master should have an IP")
@@ -192,7 +192,7 @@ func CreateMacvtapInterfaceDocker(tapName *string, master string) (
 
 	routes, err := netlink.RouteList(masterLink, netlink.FAMILY_V4)
 	if err != nil {
-		return nil, nil, nil, "", err
+		return nil, nil, nil, "", errors.Wrap(err, "Unable to get route list")
 	}
 	if len(routes) == 0 {
 		return nil, nil, nil, "",
@@ -204,17 +204,17 @@ func CreateMacvtapInterfaceDocker(tapName *string, master string) (
 	// ip addr del $INET_STR dev master
 	err = netlink.AddrDel(masterLink, &masterAddr)
 	if err != nil {
-		return nil, nil, nil, "", err
+		return nil, nil, nil, "", errors.Wrap(err, "Unable to delete address of master")
 	}
 
 	err = netlink.LinkSetUp(macvtapLink)
 	if err != nil {
-		return nil, nil, nil, "", err
+		return nil, nil, nil, "", errors.Wrap(err, "Unable to set up tap link")
 	}
 
 	err = netlink.LinkSetUp(masterLink)
 	if err != nil {
-		return nil, nil, nil, "", err
+		return nil, nil, nil, "", errors.Wrap(err, "Unable to set up master link")
 	}
 
 	// The HardwareAddr Attr doesn't automatically get updated

--- a/runnc-cont/runnc_cont.go
+++ b/runnc-cont/runnc_cont.go
@@ -138,8 +138,10 @@ func run(nablarun string, unikernel string, tapName string,
 			return 1
 		}
 	} else if inK8s {
-		// The tap device will get the IP assigned to the Docker
+		// The tap device will get the IP assigned to the k8s nabla
 		// container veth pair.
+		// XXX: This is a workaround due to an error with MacvTap, error was :
+		// Could not create /dev/tap8863: open /sys/devices/virtual/net/macvtap8863/tap8863/dev: no such file or directory
 		ip, gw, mask, err = network.CreateTapInterfaceDocker(tapName, "eth0")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Could not create %s: %v\n", tapName, err)


### PR DESCRIPTION
Added modifications to work with networking of k8s CNI plugin using network namespace for now.

```lumjjb@lumjjb-ThinkPad-P50:~/go/src/github.com/nabla-containers/runnc/runnc-cli$ cat ~/deploys/nabla.yaml
apiVersion: apps/v1beta1
kind: Deployment
metadata:
  labels:
    app: nabla
  name: nabla
spec:
  replicas: 1
  template:
    metadata:
      labels:
        app: nabla
      name: nabla
      annotations:
        io.kubernetes.cri.untrusted-workload: "true"
    spec:
      containers:
        - name: nabla
          image: nablact/node-express-nabla:latest
          imagePullPolicy: Always
          ports:
          - containerPort: 8080

lumjjb@lumjjb-ThinkPad-P50:~/go/src/github.com/nabla-containers/runnc/runnc-cli$ cat ~/services/nabla.yaml
kind: Service
apiVersion: v1
metadata:
  name: nabla-service
spec:
  selector:
    app: nabla
  ports:
  - port: 8080
    targetPort: 8080
lumjjb@lumjjb-ThinkPad-P50:~/go/src/github.com/nabla-containers/runnc/runnc-cli$ k get services
NAME            TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
kubernetes      ClusterIP   10.0.0.1     <none>        443/TCP    1h
nabla-service   ClusterIP   10.0.0.67    <none>        8080/TCP   4m
lumjjb@lumjjb-ThinkPad-P50:~/go/src/github.com/nabla-containers/runnc/runnc-cli$ k get pods
NAME                      READY   STATUS    RESTARTS   AGE
myubuntu-5ff9c565-54w29   1/1     Running   0          12m
myubuntu-5ff9c565-ssvk6   1/1     Running   0          12m
myubuntu-5ff9c565-v67gr   1/1     Running   0          12m
nabla-857c6d9b9-rqntw     1/1     Running   0          20s
lumjjb@lumjjb-ThinkPad-P50:~/go/src/github.com/nabla-containers/runnc/runnc-cli$ curl 10.0.0.67:8080
Nabla!
```
Signed-off-by: Brandon Lum <lumjjb@gmail.com>