### PR TITLE
Updated to work with docker prestart hooks for network setup

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -1,5 +1,9 @@
 package configs
 
+import (
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
 type Config struct {
 	Args   []string `json:"args"`
 	Rootfs string   `json:"rootfs"`
@@ -14,6 +18,9 @@ type Config struct {
 
 	// Network namespace
 	NetnsPath string `json:"netnspath"`
+
+	// Hooks configures callbacks for container lifecycle events.
+	Hooks *spec.Hooks `json:"hooks,omitempty"`
 }
 
 // HostUID returns the UID to run the nabla container as. Default is root.

--- a/libcontainer/configs/spec.go
+++ b/libcontainer/configs/spec.go
@@ -40,6 +40,7 @@ func ParseSpec(s *specs.Spec) (*Config, error) {
 		Version:   s.Version,
 		NetnsPath: netnsPath,
 		Labels:    labels,
+		Hooks:     s.Hooks,
 	}
 
 	return &cfg, nil

--- a/libcontainer/container_nabla.go
+++ b/libcontainer/container_nabla.go
@@ -202,13 +202,16 @@ func (c *nablaContainer) start(p *Process) error {
 
 	defer parentPipe.Close()
 	config := initConfig{
-		Root:      c.config.Rootfs,
-		Args:      c.config.Args,
-		FsPath:    c.fsPath,
-		Cwd:       c.config.Cwd,
-		Env:       c.config.Env,
-		TapName:   nablaTapName(c.id),
-		NetnsPath: c.config.NetnsPath,
+		Id:         c.id,
+		BundlePath: c.root,
+		Root:       c.config.Rootfs,
+		Args:       c.config.Args,
+		FsPath:     c.fsPath,
+		Cwd:        c.config.Cwd,
+		Env:        c.config.Env,
+		TapName:    nablaTapName(c.id),
+		NetnsPath:  c.config.NetnsPath,
+		Hooks:      c.config.Hooks,
 	}
 
 	enc := json.NewEncoder(parentPipe)

--- a/libcontainer/hooks.go
+++ b/libcontainer/hooks.go
@@ -1,0 +1,68 @@
+package libcontainer
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+func runHook(hook spec.Hook, cid, bundlePath string) error {
+	// Adapted from:
+	// github.com/kata-containers/runtime/cli/hook.go
+	state := spec.State{
+		Pid:    os.Getpid(),
+		Bundle: bundlePath,
+		ID:     cid,
+	}
+
+	stateJSON, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := &exec.Cmd{
+		Path:   hook.Path,
+		Args:   hook.Args,
+		Env:    hook.Env,
+		Stdin:  bytes.NewReader(stateJSON),
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	if hook.Timeout == nil {
+		if err := cmd.Wait(); err != nil {
+			return fmt.Errorf("%s: stdout: %s, stderr: %s", err, stdout.String(), stderr.String())
+		}
+	} else {
+		done := make(chan error, 1)
+		go func() {
+			done <- cmd.Wait()
+			close(done)
+		}()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				return fmt.Errorf("%s: stdout: %s, stderr: %s", err, stdout.String(), stderr.String())
+			}
+		case <-time.After(time.Duration(*hook.Timeout) * time.Second):
+			if err := syscall.Kill(cmd.Process.Pid, syscall.SIGKILL); err != nil {
+				return err
+			}
+
+			return fmt.Errorf("Hook timeout")
+		}
+	}
+
+	return nil
+}

--- a/runnc-cli/runnc.go
+++ b/runnc-cli/runnc.go
@@ -116,7 +116,6 @@ func main() {
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {
 			logrus.SetLevel(logrus.DebugLevel)
-			fmt.Fprintln(os.Stderr, "Setting debug level")
 		}
 		if path := context.GlobalString("log"); path != "" {
 			f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND|os.O_SYNC, 0666)

--- a/runnc-cli/state.go
+++ b/runnc-cli/state.go
@@ -63,9 +63,6 @@ instance of a container.`,
 		}
 		os.Stdout.Write(data)
 
-		// DEBUG
-		os.Stderr.Write(data)
-
 		return nil
 	},
 }


### PR DESCRIPTION
Implemented Docker networking (via `libnetwork-setkey` prehook):

```
lumjjb@lumjjb-ThinkPad-P50:~/go/src/github.com/nabla-containers/runnc/runnc-cli$ sudo docker run --rm --runtime=runnc2 nablact/node-express-nabla:latest  &
[1] 1885
lumjjb@lumjjb-ThinkPad-P50:~/go/src/github.com/nabla-containers/runnc/runnc-cli$ [/opt/runnc/bin/nabla-run --mem=512 --net=tap3192a6cf5e37 --disk=/var/run/docker/runtime-runnc2/moby/3192a6cf5e375d80ca4921a7322f7a3c6c9f312f5bbaae5041711b85315ac2be/rootfs.iso /var/lib/docker/aufs/mnt/bbc9d22899e6309385dd7d6e2066543e3ebf9d01823ac5d31dadf4c09a047895/node.nabla {"env":"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","env":"HOSTNAME=3192a6cf5e37","cmdline":"/var/lib/docker/aufs/mnt/bbc9d22899e6309385dd7d6e2066543e3ebf9d01823ac5d31dadf4c09a047895/node.nabla /home/node/app/app.js","net":{"if":"ukvmif0","cloner":"True","type":"inet","method":"static","addr":"172.17.0.2","mask":"16","gw":"172.17.0.1"},"blk":{"source":"etfs","path":"/dev/ld0a","fstype":"blk","mountpoint":"/"},"cwd":"/"}]
            |      ___|
  __|  _ \  |  _ \ __ \
\__ \ (   | | (   |  ) |
____/\___/ _|\___/____/
Solo5: Memory map: 512 MB addressable:
Solo5:     unused @ (0x0 - 0xfffff)
Solo5:       text @ (0x100000 - 0xaed6f7)
Solo5:     rodata @ (0xaed6f8 - 0xda55b7)
Solo5:       data @ (0xda55b8 - 0xfdbea7)
Solo5:       heap >= 0xfdc000 < stack < 0x20000000
rump kernel bare metal bootstrap

Copyright (c) 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005,
    2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016
    The NetBSD Foundation, Inc.  All rights reserved.
Copyright (c) 1982, 1986, 1989, 1991, 1993
    The Regents of the University of California.  All rights reserved.

NetBSD 7.99.34 (RUMP-ROAST)
total memory = 247 MB
timecounter: Timecounters tick every 10.000 msec
timecounter: Timecounter "clockinterrupt" frequency 100 Hz quality 0
cpu0 at thinair0: rump virtual cpu
root file system type: rumpfs
kern.module.path=/stand/amd64/7.99.34/modules
mainbus0 (root)
timecounter: Timecounter "bmktc" frequency 1000000000 Hz quality 100
ukvmif0: Ethernet address 66:7c:0b:58:28:75
/dev//dev/ld0a: hostpath XENBLK_/dev/ld0a (41668 KB)
mounted tmpfs on /tmp

=== calling "/var/lib/docker/aufs/mnt/bbc9d22899e6309385dd7d6e2066543e3ebf9d01823ac5d31dadf4c09a047895/node.nabla" main() ===

rumprun: call to ``_sys___sigprocmask14'' ignored
rumprun: call to ``sigaction'' ignored
Listening on port 8080

lumjjb@lumjjb-ThinkPad-P50:~/go/src/github.com/nabla-containers/runnc/runnc-cli$ docker ps
CONTAINER ID        IMAGE                               COMMAND                  CREATED             STATUS              PORTS               NAMES
3192a6cf5e37        nablact/node-express-nabla:latest   "/node.nabla /home/n…"   4 seconds ago       Up 3 seconds                            practical_lovelace
lumjjb@lumjjb-ThinkPad-P50:~/go/src/github.com/nabla-containers/runnc/runnc-cli$ docker inspect --format '{{ .NetworkSettings.IPAddress }}'  3192a6cf5e37
172.17.0.2
lumjjb@lumjjb-ThinkPad-P50:~/go/src/github.com/nabla-containers/runnc/runnc-cli$ curl 172.17.0.2:8080
Nabla!
```

Signed-off-by: Brandon Lum <lumjjb@gmail.com>