### PR TITLE
Updated release version to current minor version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ submodule_warning:
 endif
 
 # Synced release version to download from
-RELEASE_VER=v0.1
+RELEASE_VER=v0.2
 
 RELEASE_SERVER=https://github.com/nabla-containers/nabla-base-build/releases/download/${RELEASE_VER}/
 


### PR DESCRIPTION
To fix issues with testing in https://github.com/nabla-containers/runnc/pull/56 with outdated `.nabla` binaries.

Signed-off-by: Brandon Lum <lumjjb@gmail.com>