### PR TITLE
Allow aarch64 builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "solo5"]
 	path = solo5
-	url = https://github.com/nabla-containers/solo5.git
-	branch = ukvm-linux-seccomp
+	url = https://github.com/solo5/solo5
+	branch = master

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,89 +2,141 @@
 
 
 [[projects]]
+  digest = "1:2e4b6024ac18cdcbbf298ea74cce50269e11964eec3668e984299df544f06004"
   name = "github.com/docker/docker"
   packages = [
     "pkg/mount",
-    "pkg/term"
+    "pkg/term",
   ]
+  pruneopts = "UT"
   revision = "a8a31eff10544860d2188dddabdee4d727545796"
   version = "v1.5.0"
 
 [[projects]]
+  digest = "1:0a69a1c0db3591fcefb47f115b224592c8dfa4368b7ba9fae509d5e16cdc95c8"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
   version = "v1.0.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:a835f6c13810d87f3c205b00ae86453ae9b85c49303180eae749ef17d515b658"
+  name = "github.com/nabla-containers/runnc"
+  packages = [
+    "libcontainer",
+    "libcontainer/configs",
+    "nabla-lib/network",
+    "nabla-lib/storage",
+  ]
+  pruneopts = "UT"
+  revision = "657ef24891fe490eeb9901ce7b0aee35a6964888"
+
+[[projects]]
+  digest = "1:807b37892d64f054664a178955adbf09e57fd4dcd71f17a6b138a7079ea7ae4f"
   name = "github.com/opencontainers/runc"
   packages = [
     "libcontainer/label",
     "libcontainer/selinux",
     "libcontainer/stacktrace",
     "libcontainer/system",
-    "libcontainer/utils"
+    "libcontainer/utils",
   ]
+  pruneopts = "UT"
   revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
   version = "v0.1.1"
 
 [[projects]]
+  digest = "1:57234a321bf1f8f98a8a9a5122a2404cc60d0800516f4ab7a7b2375e4b2d19ea"
   name = "github.com/opencontainers/runtime-spec"
   packages = ["specs-go"]
+  pruneopts = "UT"
   revision = "4e3b9264a330d094b0386c3703c5f379119711e8"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:b17bd7b89f445e9c4b82f6144a8fe41e60d921fbe4279f669f9464b277927254"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = "UT"
   revision = "680f584d621da87ee04ea659130e149ba9d23cae"
 
 [[projects]]
+  digest = "1:b24d38b282bacf9791408a080f606370efa3d364e4b5fd9ba0f7b87786d3b679"
   name = "github.com/urfave/cli"
   packages = ["."]
+  pruneopts = "UT"
   revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
   version = "v1.20.0"
 
 [[projects]]
+  digest = "1:2d9d06cb9d46dacfdbb45f8575b39fc0126d083841a29d4fbf8d97708f43107e"
   name = "github.com/vishvananda/netlink"
   packages = [
     ".",
-    "nl"
+    "nl",
   ]
+  pruneopts = "UT"
   revision = "a2ad57a690f3caf3015351d2d6e1c0b95c349752"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:e4e30678fb2560b5c62f6308c5023d6c294fc7713216fa379411cc74465e866f"
   name = "github.com/vishvananda/netns"
   packages = ["."]
+  pruneopts = "UT"
   revision = "13995c7128ccc8e51e9a6bd2b551020a27180abd"
 
 [[projects]]
   branch = "master"
+  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = "UT"
   revision = "0c41d7ab0a0ee717d4590a44bcb987dfd9e183eb"
 
 [[projects]]
   branch = "master"
+  digest = "1:f5aa274a0377f85735edc7fedfb0811d3cbc20af91633797cb359e29c3272271"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "UT"
   revision = "fa43e7bc11baaae89f3f902b2b4d832b68234844"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "161a6358b5d2b899cb8a657abf464b14118ff68e1531d527d326703010500ad6"
+  input-imports = [
+    "github.com/docker/docker/pkg/term",
+    "github.com/nabla-containers/runnc/libcontainer",
+    "github.com/nabla-containers/runnc/libcontainer/configs",
+    "github.com/nabla-containers/runnc/nabla-lib/network",
+    "github.com/nabla-containers/runnc/nabla-lib/storage",
+    "github.com/opencontainers/runc/libcontainer/label",
+    "github.com/opencontainers/runc/libcontainer/stacktrace",
+    "github.com/opencontainers/runc/libcontainer/system",
+    "github.com/opencontainers/runc/libcontainer/utils",
+    "github.com/opencontainers/runtime-spec/specs-go",
+    "github.com/pkg/errors",
+    "github.com/sirupsen/logrus",
+    "github.com/urfave/cli",
+    "github.com/vishvananda/netlink",
+    "github.com/vishvananda/netns",
+    "golang.org/x/sys/unix",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
- check architecture for the GO os/arch tuple
- update solo5 submodule to point to upstream

Rough commit, stripping out various stuff.