### PR TITLE
solo5: update to point to the latest upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "solo5"]
 	path = solo5
-	url = https://github.com/nabla-containers/solo5.git
-	branch = ukvm-linux-seccomp
+	url = https://github.com/solo5/solo5.git
+	branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@
 #
 # Based on the opencontainers/runc .travis.yml file.
 
+dist: xenial
 language: go
 go:
   - 1.11.x
@@ -21,9 +22,8 @@ services:
   - docker
 
 before_install:
-  - echo "deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get -qq update
-  - sudo apt-get install -y libseccomp-dev/trusty-backports genisoimage jq
+  - sudo apt-get install -y libseccomp-dev genisoimage jq
   - go get -u golang.org/x/lint/golint
   - go get -u github.com/vbatts/git-validation
   - go get -u github.com/golang/dep/cmd/dep

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ tests/integration/test_curl.nabla:
 install: build/runnc build/nabla-run
 	sudo hack/copy_binaries.sh
 
-.PHONY: test,container-integration-test,local-integration-test,integration
+.PHONY: test,container-integration-test,local-integration-test,integration,integration-make
 test: integration
 
 test_images: \
@@ -88,10 +88,10 @@ tests/integration/test_curl.nabla
 
 integration: local-integration-test
 
-test/integration/node_tests.iso:
+integration-make:
 	make -C tests/integration
 
-local-integration-test: test/integration/node_tests.iso
+local-integration-test: integration-make
 	sudo tests/bats-core/bats -p tests/integration
 
 #container-integration-test: test/integration/node_tests.iso

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ submodule_warning:
 endif
 
 # Synced release version to download from
-RELEASE_VER=v0.2
+RELEASE_VER=v0.3
 
 RELEASE_SERVER=https://github.com/nabla-containers/nabla-base-build/releases/download/${RELEASE_VER}/
 

--- a/Makefile
+++ b/Makefile
@@ -55,21 +55,21 @@ godep:
 build/runnc: godep create.go exec.go kill.go start.go util.go util_runner.go util_tty.go delete.go  init.go runnc.go state.go util_nabla.go util_signal.go
 	GOOS=linux GOARCH=amd64 go build -o $@ .
 
-solo5/ukvm/ukvm-bin: FORCE
-	make -C solo5 ukvm
+solo5/tenders/spt/solo5-spt: FORCE
+	make -C solo5
 
-solo5/tests/test_hello/test_hello.ukvm: FORCE
-	make -C solo5 ukvm
+solo5/tests/test_hello/test_hello.spt: FORCE
+	make -C solo5
 
 .PHONY: FORCE
 
-build/nabla-run: solo5/ukvm/ukvm-bin
+build/nabla-run: solo5/tenders/spt/solo5-spt
 	install -m 775 -D $< $@
 
 tests/integration/node.nabla:
 	wget -nc ${RELEASE_SERVER}/node.nabla -O $@ && chmod +x $@
 
-tests/integration/test_hello.nabla: solo5/tests/test_hello/test_hello.ukvm
+tests/integration/test_hello.nabla: solo5/tests/test_hello/test_hello.spt
 	install -m 664 -D $< $@
 
 tests/integration/test_curl.nabla:

--- a/runnc-cont/runnc_cont.go
+++ b/runnc-cont/runnc_cont.go
@@ -178,6 +178,7 @@ func (r *RunncCont) Run() error {
 	var args []string
 	if mac != "" {
 		args = []string{r.NablaRunBin,
+			"--x-exec-heap",
 			"--mem=" + strconv.FormatInt(r.Memory, 10),
 			"--net-mac=" + mac,
 			"--net=" + r.Tap,
@@ -186,6 +187,7 @@ func (r *RunncCont) Run() error {
 			unikernelArgs}
 	} else {
 		args = []string{r.NablaRunBin,
+			"--x-exec-heap",
 			"--mem=" + strconv.FormatInt(r.Memory, 10),
 			"--net=" + r.Tap,
 			"--disk=" + disk,

--- a/tests/integration/Dockerfile.node
+++ b/tests/integration/Dockerfile.node
@@ -1,3 +1,4 @@
-FROM nablact/nabla-node-base
+FROM scratch
 
+COPY node.nabla /node.nabla
 COPY testdata/hello /hello

--- a/tests/integration/run.bats
+++ b/tests/integration/run.bats
@@ -31,7 +31,7 @@ function teardown() {
 function docker_node_nabla_run() {
 	local-test
 
-	run sudo docker run --rm --runtime=runnc nablact/nabla-node:test
+	run sudo docker run --rm --runtime=runnc nablact/nabla-node:test /node.nabla
 
 	echo "nabla-run $@ (status=$status):" >&2
 	echo "$output" >&2
@@ -192,7 +192,7 @@ function runnc_run() {
 @test "node hello runnc" {
 	local-test
 
-	run sudo docker run --rm --runtime=runnc nablact/nabla-node:test /hello/app.js
+	run sudo docker run --rm --runtime=runnc nablact/nabla-node:test /node.nabla /hello/app.js
 	[[ "$output" == *"hello from node"* ]]
 }
 
@@ -200,7 +200,7 @@ function runnc_run() {
 	local-test
 
 	# env.js just prints the NABLA_ENV_TEST environment variable
-	run sudo docker run --rm --runtime=runnc -e NABLA_ENV_TEST=blableblibloblu nablact/nabla-node:test /hello/env.js
+	run sudo docker run --rm --runtime=runnc -e NABLA_ENV_TEST=blableblibloblu nablact/nabla-node:test /node.nabla /hello/env.js
 	[[ "$output" == *"env=blableblibloblu"* ]]
 }
 
@@ -231,7 +231,7 @@ function runnc_run() {
 	# Check that 1024m is passed correct to runnc as 1024.
 	# Redirecting stderr to dev/null because there is a kernel warning
 	memory_check() {
-	  sudo docker run -d --rm --runtime=runnc -m 1024m nablact/nabla-node:test /hello/app.js 2>/dev/null
+	  sudo docker run -d --rm --runtime=runnc -m 1024m nablact/nabla-node:test /node.nabla /hello/app.js 2>/dev/null
 	}
 
 	run memory_check


### PR DESCRIPTION
- update submodule
- fix ukvm->spt naming changes
- update travis, gcc >= 4.9 needed

Signed-off-by: Anastassios Nanos <anastassios.nanos@gmail.com>