### PR TITLE
resolve hostnames: Include standard /etc files from host OS

### DIFF
--- a/libcontainer/configs/config.go
+++ b/libcontainer/configs/config.go
@@ -24,6 +24,10 @@ type Config struct {
 
 	// Memory is passed from docker cli to runtime.
 	Memory int64 `json:"memory,omitempty"`
+
+	// Mounts specify source and destination paths that will be copied
+	// inside the container's rootfs.
+	Mounts []spec.Mount `json:"mounts,omitempty"`
 }
 
 // HostUID returns the UID to run the nabla container as. Default is root.

--- a/libcontainer/configs/spec.go
+++ b/libcontainer/configs/spec.go
@@ -52,6 +52,7 @@ func ParseSpec(s *specs.Spec) (*Config, error) {
 		Labels:    labels,
 		Hooks:     s.Hooks,
 		Memory:    memory,
+		Mounts:    s.Mounts,
 	}
 
 	return &cfg, nil

--- a/libcontainer/container_nabla.go
+++ b/libcontainer/container_nabla.go
@@ -214,6 +214,7 @@ func (c *nablaContainer) start(p *Process) error {
 		NetnsPath:  c.config.NetnsPath,
 		Hooks:      c.config.Hooks,
 		Memory:     c.config.Memory,
+		Mounts:     c.config.Mounts,
 	}
 
 	enc := json.NewEncoder(parentPipe)

--- a/libcontainer/factory_nabla.go
+++ b/libcontainer/factory_nabla.go
@@ -91,10 +91,9 @@ func createRootfsISO(config *configs.Config, containerRoot string) (string, erro
 		if (mount.Destination == "/etc/resolv.conf") ||
 			(mount.Destination == "/etc/hosts") ||
 			(mount.Destination == "/etc/hostname") {
-			var dest = filepath.Join(rootfsPath, mount.Destination)
-			var source = mount.Source
-			var err = utils.Copy(dest, source)
-			if err != nil {
+			dest := filepath.Join(rootfsPath, mount.Destination)
+			source := mount.Source
+			if err := utils.Copy(dest, source); err != nil {
 				return "", errors.Wrap(err, "Unable to copy " + source + " to " + dest)
 			}
 		}

--- a/libcontainer/init_nabla.go
+++ b/libcontainer/init_nabla.go
@@ -53,6 +53,7 @@ func newRunncCont(cfg *initConfig) (*runnc_cont.RunncCont, error) {
 		WorkingDir:     cfg.Cwd,
 		Env:            cfg.Env,
 		NablaRunArgs:   cfg.Args[1:],
+		Mounts:         cfg.Mounts,
 	}
 
 	cont, err := runnc_cont.NewRunncCont(c)
@@ -75,6 +76,7 @@ type initConfig struct {
 	NetnsPath  string      `json:"netnspath"`
 	Hooks      *spec.Hooks `json:"hooks"`
 	Memory     int64       `json:"mem"`
+	Mounts     []spec.Mount `json:"Mounts"`
 }
 
 func initNabla() error {

--- a/runnc-cont/config.go
+++ b/runnc-cont/config.go
@@ -1,5 +1,9 @@
 package runnc_cont
 
+import (
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
 // Config configuration to create a runnc-cont
 type Config struct {
 	// NablaRunBin is the path to 'nabla-run' binary.
@@ -34,4 +38,8 @@ type Config struct {
 
 	// Env is a list of environment variables.
 	Env []string
+
+	// Mounts specify source and destination paths that will be copied
+	// inside the container's rootfs.
+	Mounts []spec.Mount
 }

--- a/runnc-cont/runnc_cont.go
+++ b/runnc-cont/runnc_cont.go
@@ -27,6 +27,7 @@ import (
 	"syscall"
 
 	"github.com/nabla-containers/runnc/nabla-lib/network"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/nabla-containers/runnc/nabla-lib/storage"
 )
 
@@ -63,6 +64,10 @@ type RunncCont struct {
 
 	// Env is a list of environment variables.
 	Env []string
+
+	// Mounts specify source and destination paths that will be copied
+	// inside the container's rootfs.
+	Mounts []spec.Mount
 }
 
 // NewRunncCont returns a brand new runnc-cont
@@ -100,6 +105,7 @@ func NewRunncCont(cfg Config) (*RunncCont, error) {
 		Disk:           cfg.Disk[0],
 		WorkingDir:     cfg.WorkingDir,
 		Env:            cfg.Env,
+		Mounts:         cfg.Mounts,
 	}, nil
 }
 


### PR DESCRIPTION
To be able to resolve hostnames from the nabla-container, we use the
Mounts dict from the docker cli config.json and cp resolv.conf, hosts
& hostname to the rootfs dir before creating the ISO fs.

This is a temporary hack. We need to figure out how to do that
properly.

Signed-off-by: Anastassios Nanos <anastassios.nanos@gmail.com>