### PR TITLE
Refactor to pull network config out of runnc-cont

### DIFF
--- a/runnc-cont/config.go
+++ b/runnc-cont/config.go
@@ -19,7 +19,8 @@ type Config struct {
 
 	IPAddress string
 	IPMask    int
-	GateWay   string
+	Gateway   string
+	Mac       string
 
 	// Memory max memory size in MBs.
 	Memory int64


### PR DESCRIPTION
Because of `runllc` work, we want to be able to pull out the network config out in front so that they can be separate modules. In this PR, we've taken the network plumbing out of `runnc` and put it in the initialization of `runnc-cont`. Doing so, we've also created a check to allow passing of ready parameters in. (i.e. we could do plumbing outside `runnc-cont` and pass in the ip, mask, gw, etc. and `runnc-cont` will honor it).

Signed-off-by: Brandon Lum <lumjjb@gmail.com>