### PR TITLE
Fix Network Issue

### DIFF
--- a/nabla-lib/network/network_linux.go
+++ b/nabla-lib/network/network_linux.go
@@ -322,7 +322,7 @@ func CreateTapInterfaceDocker(tapName string, master string) (
 		return nil, nil, nil, "", err
 	}
 
-	// defaukt-br0 has to be removed first if exists	
+	// default-br0 has to be removed first if exists	
 	br, err := netlink.LinkByName("br0")
 	if br != nil {
 		err := netlink.LinkDel(br)

--- a/nabla-lib/network/network_linux.go
+++ b/nabla-lib/network/network_linux.go
@@ -287,7 +287,7 @@ func CreateTapInterfaceDocker(tapName string, master string) (
 		return nil, nil, nil, "",
 			fmt.Errorf("no master interface: %v", err)
 	}
-	masterAddr, masterIP, masterMask, gwAddr, mac, err := getMasterDetails(masterLink)
+	_, masterIP, masterMask, gwAddr, mac, err := getMasterDetails(masterLink)
 	if err != nil {
 		return nil, nil, nil, "", err
 	}
@@ -312,12 +312,6 @@ func CreateTapInterfaceDocker(tapName string, master string) (
 		return nil, nil, nil, "", err
 	}
 
-	// ip addr del $INET_STR dev master
-	err = netlink.AddrDel(masterLink, masterAddr)
-	if err != nil {
-		return nil, nil, nil, "", err
-	}
-
 	genmac, err := net.ParseMAC("aa:aa:aa:aa:bb:cc")
 	if err != nil {
 		return nil, nil, nil, "", err
@@ -327,6 +321,15 @@ func CreateTapInterfaceDocker(tapName string, master string) (
 	if err != nil {
 		return nil, nil, nil, "", err
 	}
+
+	// defaukt-br0 has to be removed first if exists	
+	br, err := netlink.LinkByName("br0")
+	if br != nil {
+		err := netlink.LinkDel(br)
+		if err != nil {
+			return nil, nil, nil, "", err
+		}
+	}	
 
 	br0, err := CreateBridge("br0")
 	if err != nil {


### PR DESCRIPTION
Got runnc running with Kubernetes and containerd 1.3.4 with this fix.
Seems like the crash occured in the first run because of an already existing bridge and afterwards the eth0-IP was missing in the netns.
Tested with docker and k8s/containerd/calico

Closes #83 